### PR TITLE
Adjust mobile padding and margins for photo grid

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -134,11 +134,16 @@ body {
   }
 }
 
-@media (max-width: 599px) {
+@media (max-width: 511px) {
   .main-content {
     margin-top: 54px;
-    padding: 0.5rem;
+  }
+}
+
+@media (max-width: 599px) {
+  .main-content {
     padding-bottom: 2rem;
+    margin-top: 54px
   }
   
   .main-content-title {
@@ -148,7 +153,6 @@ body {
 
 @media (max-width: 480px) {
   .main-content {
-    padding: 0.375rem;
     padding-bottom: 2rem;
   }
 }

--- a/frontend/src/components/PhotoGrid.css
+++ b/frontend/src/components/PhotoGrid.css
@@ -59,11 +59,23 @@
   transform: none;
 }
 
+@media (max-width: 511px) {
+  .photo-grid {
+    padding-top: 54px;
+  }
+}
+
 /* 2 columns for tablets - this is dynamically controlled by PhotoGrid.tsx */
 @media (min-width: 512px) {
   .photo-grid {
     grid-template-columns: repeat(2, 1fr);
     margin-top: 54px;
+  }
+}
+
+@media (max-width: 599px) {
+  .photo-grid {
+    margin-top: 0px;
   }
 }
 


### PR DESCRIPTION
- Update breakpoints for main content padding
- Add padding-top to photo grid on mobile (<512px)
- Remove margin-top on photo grid for tablets (599px)
- Clean up mobile padding breakpoints