### PR TITLE
fix(setup): Fix restart timing - backend restarts immediately, fronte…

### DIFF
--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -460,7 +460,7 @@ router.post('/initialize', async (req: Request, res: Response): Promise<void> =>
     setTimeout(() => {
       console.log('✓ Setup complete - exiting for restart');
       process.exit(0); // Exit cleanly - PM2 will restart the process
-    }, 5000); // Wait 5 seconds to ensure response is sent and give frontend time to show message
+    }, 500); // Wait 500ms to ensure response is sent, then restart immediately
   } catch (error) {
     console.error('Setup initialization failed:', error);
     res.status(500).json({ 

--- a/frontend/src/components/SetupWizard/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.tsx
@@ -180,7 +180,7 @@ export default function SetupWizard() {
       setCurrentStep(4);
 
       // Show countdown while server restarts
-      let countdown = 5;
+      let countdown = 8;
       const countdownInterval = setInterval(() => {
         countdown--;
         if (countdown > 0) {
@@ -191,7 +191,7 @@ export default function SetupWizard() {
         }
       }, 1000);
 
-      // Redirect after 5 seconds (matching backend restart delay)
+      // Wait 8 seconds for backend to restart before redirecting
       setTimeout(() => {
         clearInterval(countdownInterval);
         if (authMethod === 'google') {
@@ -201,7 +201,7 @@ export default function SetupWizard() {
           // For password auth, redirect to admin portal (will show login)
           window.location.href = '/admin';
         }
-      }, 5000);
+      }, 8000);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Setup failed. Please try again.');
       console.error('Setup initialization failed:', err);


### PR DESCRIPTION
…nd waits longer

Backend changes:
- Reduced restart delay from 5s to 500ms
- Backend exits and restarts immediately after sending response

Frontend changes:
- Increased countdown from 5s to 8s
- Gives backend time to fully restart before redirecting
- User sees: "Hang on while the server starts up... (8)" → countdown to 1

This prevents 502 errors when redirecting too quickly after backend restart. The backend restarts first, then frontend waits for it to be ready.