### PR TITLE
Security: Add path sanitization and fix upload error handling

### DIFF
--- a/frontend/src/components/AdminPortal/AlbumsManager/types.ts
+++ b/frontend/src/components/AdminPortal/AlbumsManager/types.ts
@@ -22,6 +22,7 @@ export interface UploadingImage {
   retryCount?: number; // Number of retry attempts (max 5)
   videoStage?: string; // Track specific video processing stage (rotation, 240p, 360p, etc.)
   message?: string; // Additional message from processing
+  isRetryable?: boolean; // Whether this error can be retried (defaults to true)
 }
 
 export interface AlbumsManagerProps {


### PR DESCRIPTION
- Add sanitization for albumName and filename in video thumbnail route to prevent shell injection and directory traversal
- Add proper Multer error handling to return 400 (client error) instead of 500 for validation errors
- Implement non-retryable error detection in frontend to prevent infinite retry loops on file validation errors
- Remove file size limit to allow uploading videos of any size
- Update error messages to be more user-friendly and include error codes