### PR TITLE
Fix unpublished album access to show 404 page instead of error message

### DIFF
--- a/frontend/src/components/ContentGrid.tsx
+++ b/frontend/src/components/ContentGrid.tsx
@@ -286,7 +286,7 @@ const ContentGrid: React.FC<ContentGridProps> = ({ album, onAlbumNotFound, initi
             `${API_URL}/api/albums/${album}/photos${queryString}`
           );
           if (!response.ok) {
-            if (response.status === 404) {
+            if (response.status === 404 || response.status === 403) {
               throw new Error("ALBUM_NOT_FOUND");
             }
             throw new Error("Failed to fetch photos");


### PR DESCRIPTION
- Treat 403 (Forbidden) responses the same as 404 (Not Found)
- Show cowboy 404 page when accessing unpublished albums without authentication
- Previously showed generic 'Failed to fetch photos' error message