### PR TITLE
Improve service worker update behavior and auth UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import { SSEToasterProvider } from "./contexts/SSEToasterContext";
 import { AuthProvider } from "./contexts/AuthContext";
 import SSEToaster from "./components/SSEToaster";
 import { filterAlbums, filterFolders } from "./utils/albumFilters";
+import { useServiceWorkerNavigationReload } from "./utils/navigationInterceptor";
 
 // Lazy load components that aren't needed on initial page load
 const AdminPortal = lazy(() => import("./components/AdminPortal"));
@@ -239,6 +240,9 @@ function App() {
   const [setupComplete, setSetupComplete] = useState<boolean | null>(null);
   const location = useLocation();
   const { isAuthenticated } = useAuth();
+  
+  // Intercept navigation to reload when service worker update is pending
+  useServiceWorkerNavigationReload();
 
   // Check if initial setup is complete
   useEffect(() => {

--- a/frontend/src/components/AdminPortal/AdminPortal.css
+++ b/frontend/src/components/AdminPortal/AdminPortal.css
@@ -538,6 +538,7 @@
   border-radius: 16px;
   padding: 3rem 2.5rem;
   width: 100%;
+  max-width: 400px;
   text-align: center;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
   position: relative;
@@ -871,6 +872,14 @@
   margin-top: 1.5rem;
   padding-top: 1.5rem;
   border-top: 1px solid #e5e7eb;
+}
+
+.auth-version {
+  text-align: center;
+  margin-top: 1rem;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.875rem;
+  font-weight: 400;
 }
 
 /* Responsive Design */

--- a/frontend/src/components/AdminPortal/LoginForm.tsx
+++ b/frontend/src/components/AdminPortal/LoginForm.tsx
@@ -13,6 +13,7 @@ import {
   HomeIcon,
   LockIcon,
 } from '../icons/';
+import packageJson from '../../../../package.json';
 
 interface LoginFormProps {
   availableAuthMethods: {
@@ -393,6 +394,11 @@ export default function LoginForm({ availableAuthMethods, onLoginSuccess }: Logi
             {t('login.returnToGallery')}
           </a>
         </div>
+      </div>
+      
+      {/* Version Display */}
+      <div className="auth-version">
+        Galleria v{packageJson.version}
       </div>
     </div>
   );

--- a/frontend/src/utils/navigationInterceptor.ts
+++ b/frontend/src/utils/navigationInterceptor.ts
@@ -1,0 +1,34 @@
+/**
+ * Navigation interceptor for service worker updates
+ * Checks if a service worker update is pending and reloads on next navigation
+ */
+
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { info } from './logger';
+
+/**
+ * Hook that intercepts navigation and reloads if a service worker update is pending
+ */
+export function useServiceWorkerNavigationReload() {
+  const location = useLocation();
+
+  useEffect(() => {
+    // Check if there's a pending service worker update
+    const hasPendingUpdate = 
+      window.__pendingServiceWorkerUpdate === true || 
+      sessionStorage.getItem('pendingServiceWorkerUpdate') === 'true';
+
+    if (hasPendingUpdate) {
+      info('[SW] Pending update detected on navigation. Reloading to apply new version...');
+      
+      // Clear the flags before reloading
+      window.__pendingServiceWorkerUpdate = false;
+      sessionStorage.removeItem('pendingServiceWorkerUpdate');
+      
+      // Reload the page to activate the new service worker
+      window.location.reload();
+    }
+  }, [location.pathname]); // Trigger on navigation (pathname change)
+}
+

--- a/frontend/src/utils/serviceWorker.ts
+++ b/frontend/src/utils/serviceWorker.ts
@@ -3,9 +3,7 @@
  * Registers and manages the service worker for caching
  */
 
-import { showToast } from "./toast";
 import { info } from '../utils/logger';
-import i18n from '../i18n/config';
 
 export function registerServiceWorker() {
   // Disable service worker on localhost (development)
@@ -63,25 +61,13 @@ export function registerServiceWorker() {
                   navigator.serviceWorker.controller
                 ) {
                   // New service worker available
-                  info("📦 New version available! Reloading...");
+                  info("📦 New version available! Will reload on next navigation.");
 
-                  // Show toast notification only in dev/local (not in production)
-                  const isProduction =
-                    window.location.hostname !== "localhost" &&
-                    window.location.hostname !== "127.0.0.1" &&
-                    !window.location.hostname.includes("dev");
-
-                  if (!isProduction) {
-                    showToast(
-                      i18n.t('serviceWorker.newVersionReloading'),
-                      "info"
-                    );
-                  }
+                  // Set global flag to trigger reload on next navigation
+                  window.__pendingServiceWorkerUpdate = true;
                   
-                  // Auto-reload after a brief delay
-                  setTimeout(() => {
-                    window.location.reload();
-                  }, 1000);
+                  // Store in sessionStorage as backup (survives if window object is cleared)
+                  sessionStorage.setItem('pendingServiceWorkerUpdate', 'true');
                 }
               });
             }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  __pendingServiceWorkerUpdate?: boolean;
+}


### PR DESCRIPTION
- Change service worker update from auto-reload to navigation-triggered reload
  - Set flag when update detected instead of immediate reload
  - Reload on next navigation click (prevents jarring homepage refresh)
  - Add navigation interceptor hook to check for pending updates

- Fix auth card styling
  - Add max-width: 400px to prevent overly wide login form
  - Add version display below auth card
  - Improve visual hierarchy on login page