### PR TITLE
Remove background color and overflow-x from admin-portal

### DIFF
--- a/frontend/src/components/AdminPortal/AdminPortal.css
+++ b/frontend/src/components/AdminPortal/AdminPortal.css
@@ -8,8 +8,6 @@
 .admin-portal {
   position: relative;
   min-height: 100vh;
-  background: #1a1a1a;
-  overflow-x: hidden; /* Prevent horizontal scroll from animated backgrounds */
 }
 
 /* Rotating gradient overlay for entire admin portal - only when animated-bg class is present */


### PR DESCRIPTION
- Remove solid #1a1a1a background to show full animated gradient
- Remove overflow-x: hidden to allow full content visibility
- Simplify .admin-portal to minimal necessary styles