### PR TITLE
Fix Docker build cache corruption - add --no-cache flag

### DIFF
--- a/.github/workflows/devel-update.yml
+++ b/.github/workflows/devel-update.yml
@@ -132,7 +132,7 @@ jobs:
           fi
 
           # Build and push with dev tag only (no version tags on devel branch)
-          docker build -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}:$TAG .
+          docker build --no-cache -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}:$TAG .
           docker push ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}:$TAG
 
           # Logout

--- a/.github/workflows/prod-update.yml
+++ b/.github/workflows/prod-update.yml
@@ -134,7 +134,7 @@ jobs:
           fi
 
           # Build and push with latest tag
-          docker build -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}:$TAG .
+          docker build --no-cache -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}:$TAG .
           docker push ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKER_IMAGE_NAME }}:$TAG
 
           # PRODUCTION ONLY: Also tag and push with version from package.json


### PR DESCRIPTION
ROOT CAUSE: Docker BuildKit cache corruption on self-hosted runner
Error: parent snapshot does not exist: not found

FIX: Add --no-cache flag to docker build command in workflows
- Forces clean build without using corrupted cache layers
- Applies to both devel and prod workflows
- Slightly slower builds but prevents cache corruption issues