### PR TITLE
Add Docker cleanup to CI/CD workflows

### DIFF
--- a/.github/workflows/devel-update.yml
+++ b/.github/workflows/devel-update.yml
@@ -138,6 +138,18 @@ jobs:
           # Logout
           docker logout
 
+      - name: Clean up old Docker images
+        if: always()
+        run: |
+          # Remove dangling images (untagged)
+          docker image prune -f
+          
+          # Remove old build cache (keeps last 24 hours)
+          docker builder prune -af --filter "until=24h"
+          
+          # Remove unused images older than 24 hours (keeps recent images)
+          docker image prune -af --filter "until=24h"
+
       - name: Update Docker Hub README
         if: success() && vars.DOCKERHUB_USERNAME
         run: |

--- a/.github/workflows/prod-update.yml
+++ b/.github/workflows/prod-update.yml
@@ -146,6 +146,18 @@ jobs:
           # Logout
           docker logout
 
+      - name: Clean up old Docker images
+        if: always()
+        run: |
+          # Remove dangling images (untagged)
+          docker image prune -f
+          
+          # Remove old build cache (keeps last 24 hours)
+          docker builder prune -af --filter "until=24h"
+          
+          # Remove unused images older than 24 hours (keeps recent images)
+          docker image prune -af --filter "until=24h"
+
       - name: Update Docker Hub README
         if: success() && vars.DOCKERHUB_USERNAME
         run: |


### PR DESCRIPTION
- Added docker image prune to remove dangling images
- Added docker builder prune to clean old build cache (>24h)
- Added docker image prune with time filter to remove old unused images (>24h)
- Cleanup runs after build/push to keep runner disk space clean
- Applied to both prod and devel workflows