### PR TITLE
Add installation analytics tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ data/
 data-backup-*/
 config/config.local.json
 
+# Installation analytics tracking
+.installation-analytics.json
+data/.installation-analytics.json
+
 # Video files (HLS playlists and segments)
 video/
 

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -1198,6 +1198,7 @@ export function updateAlbumMilestone(album: string, milestone: number): void {
   stmt.run(milestone, album);
 }
 
+
 /**
  * Close the database connection
  */

--- a/backend/src/utils/installation-analytics.ts
+++ b/backend/src/utils/installation-analytics.ts
@@ -1,0 +1,119 @@
+/**
+ * Installation Analytics Utility
+ * Sends installation events to the central analytics server
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { DATA_DIR } from '../config.js';
+import { info, warn, error } from './logger.js';
+
+const INSTALL_ANALYTICS_URL = 'https://galleria.website/api/analytics/install';
+
+/**
+ * Get the path to the installation analytics tracking file
+ */
+function getTrackingFilePath(): string {
+  return path.join(DATA_DIR, '.installation-analytics.json');
+}
+
+/**
+ * Check if an installation analytics event has been sent
+ */
+function hasInstallationEventBeenSent(eventType: string): boolean {
+  try {
+    const trackingFile = getTrackingFilePath();
+    if (!fs.existsSync(trackingFile)) {
+      return false;
+    }
+
+    const content = fs.readFileSync(trackingFile, 'utf8');
+    const tracking = JSON.parse(content);
+    return tracking[eventType] === true;
+  } catch (err) {
+    // If file doesn't exist or is invalid, event hasn't been sent
+    return false;
+  }
+}
+
+/**
+ * Mark an installation analytics event as sent
+ */
+function markInstallationEventSent(eventType: string): void {
+  try {
+    const trackingFile = getTrackingFilePath();
+    const trackingDir = path.dirname(trackingFile);
+    
+    // Ensure directory exists
+    if (!fs.existsSync(trackingDir)) {
+      fs.mkdirSync(trackingDir, { recursive: true });
+    }
+
+    // Read existing tracking or create new
+    let tracking: Record<string, boolean> = {};
+    if (fs.existsSync(trackingFile)) {
+      try {
+        const content = fs.readFileSync(trackingFile, 'utf8');
+        tracking = JSON.parse(content);
+      } catch (err) {
+        // If file is invalid, start fresh
+        tracking = {};
+      }
+    }
+
+    // Mark event as sent
+    tracking[eventType] = true;
+
+    // Write back to file
+    fs.writeFileSync(trackingFile, JSON.stringify(tracking, null, 2), 'utf8');
+  } catch (err) {
+    error(`[Installation Analytics] Failed to mark ${eventType} as sent:`, err);
+  }
+}
+
+/**
+ * Send an installation analytics event to the central server
+ * Only sends if the event hasn't been sent before
+ */
+export async function sendInstallationEvent(
+  eventType: 'installation_started' | 'setup_complete',
+  eventData?: Record<string, any>
+): Promise<boolean> {
+  try {
+    // Check if event has already been sent
+    if (hasInstallationEventBeenSent(eventType)) {
+      info(`[Installation Analytics] Event ${eventType} already sent, skipping`);
+      return false;
+    }
+
+    // Prepare the event payload
+    const payload = {
+      event_type: eventType,
+      timestamp: new Date().toISOString(),
+      ...eventData,
+    };
+
+    // Send to central analytics server
+    const response = await fetch(INSTALL_ANALYTICS_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      warn(`[Installation Analytics] Failed to send ${eventType}:`, response.status, errorText);
+      return false;
+    }
+
+    // Mark event as sent in file
+    markInstallationEventSent(eventType);
+    info(`[Installation Analytics] Successfully sent ${eventType} event`);
+    return true;
+  } catch (err) {
+    error(`[Installation Analytics] Error sending ${eventType}:`, err);
+    return false;
+  }
+}


### PR DESCRIPTION
- Send installation_started event when OOBE begins (GET /api/setup/status)
- Send setup_complete event when setup finishes (POST /api/setup/initialize)
- Track sent events in data/.installation-analytics.json to prevent duplicates
- POST events to https://galleria.website/api/analytics/install
- Add tracking file to .gitignore