### PR TITLE
Remove color customization from OOBE

### DIFF
--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -256,8 +256,6 @@ router.post(
         adminPassword,
         googleClientId,
         googleClientSecret,
-        primaryColor,
-        secondaryColor,
         metaDescription,
         language,
       } = req.body;
@@ -458,8 +456,6 @@ router.post(
 
       // Update config with user-provided values
       config.branding.siteName = siteName;
-      config.branding.primaryColor = primaryColor || "#4ade80";
-      config.branding.secondaryColor = secondaryColor || "#22c55e";
       config.branding.metaDescription =
         metaDescription || `Photography portfolio by ${siteName}`;
       config.branding.metaKeywords = `photography, portfolio, ${siteName.toLowerCase()}`;

--- a/frontend/src/components/SetupWizard/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.tsx
@@ -26,8 +26,6 @@ export default function SetupWizard() {
   const [authorizedEmail, setAuthorizedEmail] = useState('');
   const [googleClientId, setGoogleClientId] = useState('');
   const [googleClientSecret, setGoogleClientSecret] = useState('');
-  const [primaryColor, setPrimaryColor] = useState('#4ade80');
-  const [secondaryColor, setSecondaryColor] = useState('#22c55e');
   const [metaDescription, setMetaDescription] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -195,8 +193,6 @@ export default function SetupWizard() {
           adminPassword: authMethod === 'password' ? adminPassword : undefined,
           googleClientId: authMethod === 'google' ? googleClientId : undefined,
           googleClientSecret: authMethod === 'google' ? googleClientSecret : undefined,
-          primaryColor,
-          secondaryColor,
           metaDescription: metaDescription || t('oobe.siteDescriptionPlaceholder', { siteName }),
           language: currentLanguage,
         }),
@@ -656,35 +652,6 @@ export default function SetupWizard() {
               <p className="step-description">
                 {t('oobe.customizeDescription')}
               </p>
-
-              <div className="form-group">
-                <label>
-                  {t('oobe.colorsLabel')}
-                  <span className="field-hint">{t('oobe.colorsHint')}</span>
-                </label>
-                <div className="color-inputs">
-                  <div className="color-input-group">
-                    <label htmlFor="primaryColor">{t('oobe.primaryColorLabel')}</label>
-                    <input
-                      type="color"
-                      id="primaryColor"
-                      value={primaryColor}
-                      onChange={(e) => setPrimaryColor(e.target.value)}
-                    />
-                    <span className="color-value">{primaryColor}</span>
-                  </div>
-                  <div className="color-input-group">
-                    <label htmlFor="secondaryColor">{t('oobe.secondaryColorLabel')}</label>
-                    <input
-                      type="color"
-                      id="secondaryColor"
-                      value={secondaryColor}
-                      onChange={(e) => setSecondaryColor(e.target.value)}
-                    />
-                    <span className="color-value">{secondaryColor}</span>
-                  </div>
-                </div>
-              </div>
 
               <div className="form-group">
                 <label htmlFor="avatar">

--- a/scripts/migrate-reset-colors.js
+++ b/scripts/migrate-reset-colors.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * Migration: Reset branding colors to defaults
+ *
+ * Changes:
+ * - Resets primaryColor to default (#4ade80)
+ * - Resets secondaryColor to default (#22c55e)
+ *
+ * This migration removes any custom color configurations set during
+ * the OOBE or through the admin portal, returning them to defaults.
+ */
+
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Default colors
+const DEFAULT_PRIMARY_COLOR = '#4ade80';
+const DEFAULT_SECONDARY_COLOR = '#22c55e';
+
+// Determine config path
+const DATA_DIR = process.env.DATA_DIR || join(__dirname, '../data');
+const CONFIG_PATH = join(DATA_DIR, 'config.json');
+
+function runMigration() {
+  console.log('Starting color reset migration...');
+  console.log(`Config path: ${CONFIG_PATH}`);
+
+  // Check if config file exists
+  if (!existsSync(CONFIG_PATH)) {
+    console.log('⚠️  Config file does not exist. Nothing to migrate.');
+    console.log('ℹ️  New installations will use default colors automatically.');
+    return;
+  }
+
+  try {
+    // Read current config
+    const configContent = readFileSync(CONFIG_PATH, 'utf8');
+    const config = JSON.parse(configContent);
+
+    // Track what we're changing
+    const oldPrimaryColor = config.branding?.primaryColor;
+    const oldSecondaryColor = config.branding?.secondaryColor;
+
+    console.log('\nCurrent colors:');
+    console.log(`  Primary:   ${oldPrimaryColor || '(not set)'}`);
+    console.log(`  Secondary: ${oldSecondaryColor || '(not set)'}`);
+
+    // Check if migration is needed
+    const needsMigration =
+      oldPrimaryColor !== DEFAULT_PRIMARY_COLOR ||
+      oldSecondaryColor !== DEFAULT_SECONDARY_COLOR;
+
+    if (!needsMigration) {
+      console.log('\n✓ Colors are already at default values. No migration needed.');
+      return;
+    }
+
+    // Ensure branding object exists
+    if (!config.branding) {
+      config.branding = {};
+    }
+
+    // Reset colors to defaults
+    config.branding.primaryColor = DEFAULT_PRIMARY_COLOR;
+    config.branding.secondaryColor = DEFAULT_SECONDARY_COLOR;
+
+    // Write updated config
+    writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8');
+
+    console.log('\nNew colors:');
+    console.log(`  Primary:   ${DEFAULT_PRIMARY_COLOR}`);
+    console.log(`  Secondary: ${DEFAULT_SECONDARY_COLOR}`);
+
+    console.log('\n✅ Migration completed successfully!');
+    console.log('ℹ️  Colors have been reset to default values.');
+    console.log('ℹ️  You may need to restart the server for changes to take effect.');
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    throw error;
+  }
+}
+
+// Run migration
+runMigration();

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -46,6 +46,18 @@ else
     echo "⚠ Skipping homepage HTML generation (system not configured yet)"
 fi
 
+# Run migrations if config exists
+if [ -f "/data/config.json" ]; then
+    echo "Running migrations..."
+
+    # Reset colors to default (removes OOBE color customization)
+    if node scripts/migrate-reset-colors.js; then
+        echo "✓ Color migration completed"
+    else
+        echo "⚠ Color migration failed (continuing anyway)"
+    fi
+fi
+
 # Generate static JSON files if config exists
 if [ -f "/data/config.json" ]; then
     echo "Generating static JSON files..."


### PR DESCRIPTION
Remove primary and secondary color options from the setup wizard. Colors now always use defaults (#4ade80, #22c55e). Added migration script that runs on Docker startup to reset existing installations.