### PR TITLE
Add iOS safe area support for header and main content

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -196,14 +196,14 @@ body {
 
 @media (max-width: 511px) {
   .main-content {
-    margin-top: 54px;
+    margin-top: calc(54px + env(safe-area-inset-top, 0px));
   }
 }
 
 @media (max-width: 599px) {
   .main-content {
     padding-bottom: 2rem;
-    margin-top: 54px;
+    margin-top: calc(54px + env(safe-area-inset-top, 0px));
   }
   
   .main-content-title {

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -8,7 +8,10 @@
   background-color: rgb(231, 231, 231);
   color: #1e1e1e;
   padding: 0 1rem;
-  height: 54px;
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-left: max(1rem, env(safe-area-inset-left, 1rem));
+  padding-right: max(1rem, env(safe-area-inset-right, 1rem));
+  height: calc(54px + env(safe-area-inset-top, 0px));
   display: flex;
   align-items: center;
   position: fixed;
@@ -427,6 +430,9 @@
 @media (max-width: 599px) {
   .header {
     padding: 0 0.5rem;
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-left: max(0.5rem, env(safe-area-inset-left, 0.5rem));
+    padding-right: max(0.5rem, env(safe-area-inset-right, 0.5rem));
   }
 
   /* Hide album title on mobile - duplicate title exists elsewhere with white text */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galleria",
-  "version": "1.0.9",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galleria",
-      "version": "1.0.9",
+      "version": "1.1.1",
       "workspaces": [
         "frontend",
         "backend"


### PR DESCRIPTION
Fixes issue where header appears behind iOS status bar after iOS update. Uses env(safe-area-inset-*) to properly position header below status bar and adjust main content margin accordingly. Includes safe area support for left/right padding on devices with notches or curved edges.