### PR TITLE
Fix Docker video path and CORS issues

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,7 @@ import config, {
   PORT,
   PHOTOS_DIR,
   OPTIMIZED_DIR,
+  DATA_DIR,
   getAllowedOrigins,
   getConfigExists,
   RATE_LIMIT_WINDOW_MS,
@@ -161,7 +162,7 @@ if (isProduction) {
 // PHOTOS_DIR should be relative to where you run the backend (typically backend/ directory)
 let photosDir = path.resolve(__dirname, "../../", PHOTOS_DIR);
 let optimizedDir = path.resolve(__dirname, "../../", OPTIMIZED_DIR);
-let videoDir = path.resolve(__dirname, "../../data/video");
+let videoDir = path.join(DATA_DIR, "video");
 
 // Resolve symlinks to get the real path (important for macOS TCC permissions)
 try {

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -488,17 +488,17 @@ app.get(/^\/.*/, async (req, res) => {
           const ipAddress = host.split(":")[0];
           runtimeApiUrl = `${protocol}://${ipAddress}:3001`;
         } else if (host.includes("localhost")) {
-          // Localhost development
-          runtimeApiUrl = "http://localhost:3001";
+          // Localhost development - use BACKEND_DOMAIN if set (for Docker port mapping)
+          runtimeApiUrl = process.env.BACKEND_DOMAIN || "http://localhost:3001";
         } else if (host.startsWith("www-")) {
           // Domain with www- prefix (e.g., www-dev.example.com -> api-dev.example.com)
           runtimeApiUrl = `${protocol}://api-${host.substring(4)}`;
         } else if (host.startsWith("www.")) {
           // Domain with www. prefix (e.g., www.example.com -> api.example.com)
           runtimeApiUrl = `${protocol}://api.${host.substring(4)}`;
-        } else if (process.env.BACKEND_DOMAIN || process.env.API_URL) {
+        } else if (process.env.BACKEND_DOMAIN) {
           // Fall back to environment variable if provided
-          runtimeApiUrl = process.env.BACKEND_DOMAIN || process.env.API_URL;
+          runtimeApiUrl = process.env.BACKEND_DOMAIN;
         } else if (
           !isSetupMode &&
           config.frontend.apiUrl &&
@@ -1077,17 +1077,17 @@ app.get(/^\/.*/, async (req, res) => {
       const ipAddress = host.split(":")[0];
       runtimeApiUrl = `${protocol}://${ipAddress}:3001`;
     } else if (host.includes("localhost")) {
-      // Localhost development
-      runtimeApiUrl = "http://localhost:3001";
+      // Localhost development - use BACKEND_DOMAIN if set (for Docker port mapping)
+      runtimeApiUrl = process.env.BACKEND_DOMAIN || "http://localhost:3001";
     } else if (host.startsWith("www-")) {
       // Domain with www- prefix (e.g., www-dev.example.com -> api-dev.example.com)
       runtimeApiUrl = `${protocol}://api-${host.substring(4)}`;
     } else if (host.startsWith("www.")) {
       // Domain with www. prefix (e.g., www.example.com -> api.example.com)
       runtimeApiUrl = `${protocol}://api.${host.substring(4)}`;
-    } else if (process.env.BACKEND_DOMAIN || process.env.API_URL) {
+    } else if (process.env.BACKEND_DOMAIN) {
       // Fall back to environment variable if provided
-      runtimeApiUrl = process.env.BACKEND_DOMAIN || process.env.API_URL;
+      runtimeApiUrl = process.env.BACKEND_DOMAIN;
     } else if (
       !isSetupMode &&
       config.frontend.apiUrl &&


### PR DESCRIPTION
- Fix videoDir to use DATA_DIR environment variable instead of hardcoded relative path. This ensures videos are found in /data/video when running in Docker with mounted volumes.

- Fix frontend runtime API URL detection to use BACKEND_DOMAIN environment variable for localhost access. This resolves CORS errors when Docker maps ports differently (e.g., 3010:3000, 3011:3001).