### PR TITLE
Fix LogViewer to use runtime API URL

### DIFF
--- a/frontend/src/components/LogViewer/LogViewer.tsx
+++ b/frontend/src/components/LogViewer/LogViewer.tsx
@@ -1,11 +1,11 @@
 // Logs are now served as standalone HTML from backend
 // This component redirects to the backend logs endpoint
 import { useEffect } from "react";
+import { API_URL } from "../../config";
 
 export default function LogViewer() {
   useEffect(() => {
     // Redirect to backend logs endpoint
-    const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
     window.location.href = `${API_URL}/logs`;
   }, []);
 


### PR DESCRIPTION
Use API_URL from config instead of build-time environment variable. This ensures the logs redirect uses the correct backend URL when running in Docker with custom port mappings or domains.