### PR TITLE
fix: restrict POST /api/system/restart to admins (ticket #538)

### DIFF
--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -8,7 +8,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { requireAuth } from '../auth/middleware.js';
+import { requireAdmin } from '../auth/middleware.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -17,7 +17,7 @@ const __dirname = path.dirname(__filename);
 const router = Router();
 
 // Restart endpoint - triggers container restart or PM2 restart
-router.post('/restart', requireAuth, (req, res) => {
+router.post('/restart', requireAdmin, (req, res) => {
   try {
     // Get user info for logging
     const userId = (req.session as any)?.userId;


### PR DESCRIPTION
## Summary

`POST /api/system/restart` was guarded only by `requireAuth`, meaning any authenticated user — including `viewer`-role accounts — could repeatedly POST and DoS the backend by triggering `pm2 restart all` / `process.exit(0)`. This swaps the middleware to the existing `requireAdmin` so only admins can initiate a restart.

- File touched: `backend/src/routes/system.ts`
- Pattern matches other admin-only routes (`config`, `folder-management`, `metrics`, etc.) that already use `requireAdmin`.
- Behavior inside the restart handler is unchanged.

## Test plan

- [ ] Authenticated viewer hits `POST /api/system/restart` → expect `403 Access denied - admin role required`
- [ ] Authenticated manager hits `POST /api/system/restart` → expect `403`
- [ ] Authenticated admin hits `POST /api/system/restart` → expect `200 { success: true }` and restart proceeds
- [ ] Unauthenticated request → expect `401 Not authenticated`

Closes ticket #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)