### PR TITLE
fix(security): use strict URL.origin equality for CSRF check (ticket #537)

### DIFF
--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -180,9 +180,30 @@ export function csrfProtection(req: any, res: any, next: any) {
   if (origin) {
     // Get dynamic allowed origins (includes config.json values)
     const allowedOrigins = getAllowedOrigins();
-    
-    // Check exact match first
-    let isAllowedOrigin = allowedOrigins.some((allowed: string) => origin.startsWith(allowed));
+
+    // Strict origin equality. Previously this used `origin.startsWith(allowed)`,
+    // which accepted a malicious origin like `https://www.example.com.attacker.com`
+    // when `https://www.example.com` was allowed. Parse both sides and compare
+    // the canonical `URL.origin` (scheme + host + port) so confusable suffixes
+    // can't bypass the check.
+    let normalizedOrigin: string | null = null;
+    try {
+      normalizedOrigin = new URL(origin).origin;
+    } catch (e) {
+      // Origin header was not a valid URL — reject below.
+    }
+
+    let isAllowedOrigin = false;
+    if (normalizedOrigin) {
+      isAllowedOrigin = allowedOrigins.some((allowed: string) => {
+        try {
+          return new URL(allowed).origin === normalizedOrigin;
+        } catch (e) {
+          warn('[CSRF] Skipping malformed allowed origin:', allowed);
+          return false;
+        }
+      });
+    }
     
     // If not in allowed list, check for localhost
     if (!isAllowedOrigin) {


### PR DESCRIPTION
## Summary
- `csrfProtection()` in `backend/src/security.ts` compared the request `Origin` against the allowed-origins list with `origin.startsWith(allowed)`. With an allowed origin of `https://www.example.com`, an attacker-controlled origin like `https://www.example.com.attacker.com` passed — combined with `credentials: true` on CORS this enabled CSRF against authenticated state-changing endpoints.
- Replaced the prefix check with strict `URL.origin` equality (`new URL(origin).origin === new URL(allowed).origin`) so confusable suffixes can no longer bypass the check.
- Each allowed-list entry is parsed inside its own try/catch so a single malformed entry logs a warning and is skipped rather than breaking CSRF for everyone. The existing localhost / direct-IP-on-3000-3001 fallbacks (Unraid WebUI access, commit `2150fb5b`) are untouched.

## Test plan
- [ ] CI build passes (`tsc`).
- [ ] Manual: with `FRONTEND_DOMAIN=https://www.example.com`, a POST whose `Origin: https://www.example.com.attacker.com` is rejected with 403 (previously accepted).
- [ ] Manual: a legitimate POST from `https://www.example.com` still succeeds.
- [ ] Manual: localhost dev (`http://localhost:5173`) and direct-IP Unraid access on `:3000`/`:3001` continue to work.

Closes ticket #537.