### PR TITLE
fix: handle spawn errors on ffmpeg/ffprobe processes (ticket #506)

### DIFF
--- a/backend/src/utils/video-processor.ts
+++ b/backend/src/utils/video-processor.ts
@@ -96,6 +96,11 @@ export async function getVideoMetadata(videoPath: string): Promise<VideoMetadata
         reject(new Error(`Failed to parse ffprobe output: ${err}`));
       }
     });
+
+    ffprobe.on('error', (err) => {
+      error('[VideoProcessor] Failed to spawn ffprobe:', err);
+      reject(new Error(`Failed to spawn ffprobe: ${err.message}`));
+    });
   });
 }
 
@@ -252,6 +257,11 @@ export async function rotateVideo(
         if (onProgress) onProgress(100);
         resolve();
       }
+    });
+
+    ffmpeg.on('error', (err) => {
+      error('[VideoProcessor] Failed to spawn ffmpeg for rotation:', err);
+      reject(new Error(`Failed to spawn ffmpeg for rotation: ${err.message}`));
     });
   });
 }
@@ -475,6 +485,11 @@ export async function generateHLS(
         resolve();
       }
     });
+
+    ffmpeg.on('error', (err) => {
+      error(`[VideoProcessor] Failed to spawn ffmpeg for ${resolution.name} HLS generation:`, err);
+      reject(new Error(`Failed to spawn ffmpeg for HLS generation: ${err.message}`));
+    });
   });
 }
 
@@ -515,6 +530,11 @@ export async function extractThumbnail(
         info(`[VideoProcessor] ${size}px thumbnail extracted successfully`);
         resolve();
       }
+    });
+
+    ffmpeg.on('error', (err) => {
+      error('[VideoProcessor] Failed to spawn ffmpeg for thumbnail extraction:', err);
+      reject(new Error(`Failed to spawn ffmpeg for thumbnail extraction: ${err.message}`));
     });
   });
 }


### PR DESCRIPTION
## Summary
- `getVideoMetadata`, `rotateVideo`, `generateHLS`, and `extractThumbnail` in `backend/src/utils/video-processor.ts` spawn `ffprobe`/`ffmpeg` but never attach an `'error'` listener. When the binary is missing from PATH, Node emits `'error'` with `ENOENT`; with no listener, EventEmitter throws and the wrapping Promise never settles — video upload SSE hangs forever and `processVideo` callers leak.
- Added `proc.on('error', (err) => reject(err))` to each of the four Promises, matching the pattern already used in `checkEncoderAvailable` and `checkFFmpeg`. Errors are also logged with the existing `error()` helper for diagnostics.
- No behavior change when ffmpeg is present; only difference is that missing/broken binaries now reject the Promise cleanly instead of hanging.

## Test plan
- [ ] CI: TypeScript compile passes on backend
- [ ] Manual: temporarily rename `ffmpeg` (or run on a host without it) and confirm an upload rejects with a clear error rather than hanging the SSE stream
- [ ] Manual: confirm a normal upload still completes end-to-end with ffmpeg installed

Fixes ticket #506.