### PR TITLE
fix: refuse /api/setup/initialize and /upload-avatar after OOBE (ticket #533)

### DIFF
--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -3,7 +3,7 @@
  * Handles initial setup and configuration for first-time users
  */
 
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -16,8 +16,38 @@ import { pipeline } from "stream/promises";
 import { createGunzip } from "zlib";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendInstallationEvent } from '../utils/installation-analytics.js';
+import { getConfigExists } from '../config.js';
 
 const router = Router();
+
+/**
+ * Guard for OOBE-only endpoints. Once config.json exists, the initial setup
+ * has already been performed and these endpoints must refuse further calls —
+ * otherwise an unauthenticated attacker could overwrite the session secret,
+ * authorized emails, OAuth credentials, allowed origins/hosts, and provision
+ * a new admin user (full account takeover). See ticket #533.
+ *
+ * The post-OOBE equivalents live behind authenticated routes (e.g.
+ * /api/branding/upload-avatar).
+ */
+function refuseIfSetupComplete(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (getConfigExists()) {
+    warn(
+      `[Setup] Refusing ${req.method} ${req.path} — setup has already completed. ` +
+      `Source IP: ${req.ip || req.socket.remoteAddress}`
+    );
+    res.status(403).json({
+      error: "Setup has already completed. This endpoint is disabled.",
+      setupComplete: true,
+    });
+    return;
+  }
+  next();
+}
 
 // Configure multer for avatar uploads
 const upload = multer({
@@ -246,6 +276,7 @@ router.get("/status", async (req: Request, res: Response): Promise<void> => {
  */
 router.post(
   "/initialize",
+  refuseIfSetupComplete,
   async (req: Request, res: Response): Promise<void> => {
     try {
       const {
@@ -755,6 +786,7 @@ router.post(
  */
 router.post(
   "/upload-avatar",
+  refuseIfSetupComplete,
   upload.single("avatar"),
   async (req: Request, res: Response): Promise<void> => {
     try {


### PR DESCRIPTION
## Summary

Fixes ticket #533 — `POST /api/setup/initialize` (and `POST /api/setup/upload-avatar`) were mounted unauthenticated with no completed-setup guard. After the out-of-box experience an attacker who can reach the endpoint could:

- overwrite `data/config.json` (sessionSecret, authorizedEmails, OAuth credentials, allowedOrigins, allowedHosts)
- provision a brand-new admin user via `createUser({ role: 'admin' })`
- have the backend reload the rewritten config

…achieving full account takeover with no session required. A reverse proxy that exposes `/api` is sufficient.

## What changed

Adds a `refuseIfSetupComplete` middleware in `backend/src/routes/setup.ts` that returns `403` when `getConfigExists()` is true, and applies it to both `/initialize` and `/upload-avatar`. Per the ticket discussion, OOBE intentionally has no auth so the very first user can create their account — `getConfigExists()` is `false` until `/initialize` writes the file and `reloadConfig()` runs, so the OOBE call still succeeds. Every subsequent call (and any call after a normal restart with a config present) is refused. The post-OOBE avatar update path already exists at the authenticated `/api/branding/upload-avatar`.

`/status` is intentionally left open — it is read-only and the wizard depends on it.

## Test plan

- [ ] Fresh install with no `data/config.json`: complete the OOBE wizard and verify `/initialize` succeeds once.
- [ ] Replay `POST /api/setup/initialize` with the same or a different payload after OOBE — expect `403 { error: "Setup has already completed.", setupComplete: true }` and verify `data/config.json` is unchanged and no new admin user was created.
- [ ] Same replay against `POST /api/setup/upload-avatar` — expect `403` and verify `data/photos/avatar.png` is unchanged.
- [ ] Restart the backend after OOBE and confirm `/initialize` continues to return `403`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)