### PR TITLE
fix: drop dead foreign_keys pragma toggles inside album rename txn (ticket #505)

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1168,39 +1168,35 @@ router.patch("/:album/rename", requireManager, async (req: Request, res: Respons
     // This way if DB update fails, filesystem is unchanged
     const db = getDatabase();
     
-    // Start transaction with foreign keys temporarily disabled
-    // This is needed because share_links has FK to albums(name) without ON UPDATE CASCADE
+    // share_links.album has ON UPDATE CASCADE (see database.ts), so renaming
+    // the album row cascades automatically. The explicit share_links UPDATE
+    // below is kept as a safety net for older databases that pre-date the
+    // migrate-share-links-cascade.js migration.
     const transaction = db.transaction(() => {
-      // Temporarily disable foreign keys for this transaction
-      db.pragma('foreign_keys = OFF');
-      
       // Update albums table
       const result = db.prepare(`
-        UPDATE albums 
+        UPDATE albums
         SET name = ?, updated_at = CURRENT_TIMESTAMP
         WHERE name = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       if (result.changes === 0) {
         throw new Error('Album not found in database');
       }
-      
+
       // Update image_metadata table
       db.prepare(`
-        UPDATE image_metadata 
+        UPDATE image_metadata
         SET album = ?, updated_at = CURRENT_TIMESTAMP
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       // Update share_links table
       db.prepare(`
-        UPDATE share_links 
+        UPDATE share_links
         SET album = ?
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
-      // Re-enable foreign keys
-      db.pragma('foreign_keys = ON');
     });
     
     transaction();


### PR DESCRIPTION
## Summary

`PATCH /:album/rename` wrapped its UPDATEs in `db.transaction(...)` and toggled `db.pragma('foreign_keys = OFF')` / `... = ON'` around them. Per [SQLite docs](https://sqlite.org/pragma.html#pragma_foreign_keys), the `foreign_keys` pragma is a no-op while a transaction is active, so the toggles never did anything — FK enforcement state was unchanged.

The schema in `backend/src/database.ts:170` already declares `share_links.album` with `ON UPDATE CASCADE` (and the dedicated `migrate-share-links-cascade.js` migration brings older databases up to that schema). The cascade fires automatically on the album rename, so the toggles aren't needed.

Removed the two dead `db.pragma(...)` lines and rewrote the surrounding comment to explain what's actually happening. The explicit `UPDATE share_links ...` is left in place as a safety net for any database that hasn't run the cascade migration yet.

## Test plan

- [ ] CI build + tests pass on the PR
- [ ] Manual: rename an album that has a `share_links` row → `albums`, `image_metadata`, and `share_links` all reflect the new name; share link still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)