### PR TITLE
fix: rename catch param to avoid shadowing error logger (ticket #502)

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -766,8 +766,8 @@ i18nInitPromise.then(() => {
           error("[Startup] ✗ Failed to generate static JSON:", result.error);
         }
       })
-      .catch((error) => {
-        error("[Startup] ✗ Failed to generate static JSON:", error);
+      .catch((err) => {
+        error("[Startup] ✗ Failed to generate static JSON:", err);
       });
   }
   });


### PR DESCRIPTION
## Summary

The `.catch` handler on the `generateStaticJSONFiles(...)` promise in `backend/src/server.ts` used `(error)` as its parameter name, which shadowed the `error` logger function imported from `./utils/logger.ts`. If the promise ever rejected, the handler would try to call `error(...)` — but `error` would be the rejection value, throwing `TypeError: error is not a function` and masking the original failure.

Renamed the parameter to `err` to match the convention already used by the sibling `.catch` blocks at lines 790 and 810. The corresponding `.then` branch on line 766 was unaffected because no parameter shadowed the logger there.

Closes ticket #502.

## Test plan

- [ ] CI typecheck/lint passes
- [ ] No behavior change on the success path; rejection path now logs via the imported `error` logger as intended