### PR TITLE
fix: invalidate credential-login sessions on user delete (ticket #503)

### DIFF
--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1531,11 +1531,48 @@ router.delete('/users/:userId', requireAdmin, async (req: Request, res: Response
           return;
         }
         
-        // Destroy sessions belonging to the deleted user
+        // Destroy sessions belonging to the deleted user.
+        // Sessions can be created by three auth flows, each storing the user
+        // identifier in a different shape:
+        //   - credential login (/login):           session.userId = <db id>
+        //   - passkey auth-verify:                  session.userId = <db id>
+        //                                           session.user.id  = <db id>
+        //   - Passport / Google OAuth:             session.passport.user = { id: googleProfileId, email, ... }
+        // Match all of them. Numeric ids are normalized via Number() in case a
+        // session store serialized ids as strings; OAuth sessions are matched
+        // by email since session.passport.user.id is the Google profile id,
+        // not the database user id.
         if (sessions) {
+          const targetId = Number(userId);
+          const targetEmail = targetUser.email ? targetUser.email.toLowerCase() : null;
           Object.keys(sessions).forEach((sid) => {
             const session = sessions[sid];
-            if (session?.passport?.user === userId) {
+            if (!session) return;
+
+            const credentialUserId = session.userId !== undefined ? Number(session.userId) : NaN;
+            const sessionUserObjId = session.user?.id !== undefined ? Number(session.user.id) : NaN;
+            const passportUser = session.passport?.user;
+            const passportUserId =
+              passportUser && typeof passportUser === 'object' && passportUser.id !== undefined
+                ? Number(passportUser.id)
+                : typeof passportUser === 'number'
+                  ? passportUser
+                  : NaN;
+            const passportEmail =
+              passportUser && typeof passportUser === 'object' && typeof passportUser.email === 'string'
+                ? passportUser.email.toLowerCase()
+                : null;
+            const sessionUserEmail =
+              typeof session.user?.email === 'string' ? session.user.email.toLowerCase() : null;
+
+            const belongsToDeletedUser =
+              credentialUserId === targetId ||
+              sessionUserObjId === targetId ||
+              passportUserId === targetId ||
+              (targetEmail !== null &&
+                (passportEmail === targetEmail || sessionUserEmail === targetEmail));
+
+            if (belongsToDeletedUser) {
               sessionStore.destroy(sid, (destroyErr) => {
                 if (destroyErr) {
                   error(`Failed to destroy session ${sid}:`, destroyErr);


### PR DESCRIPTION
## Summary

Fixes ticket #503. The session-cleanup loop in `DELETE /users/:userId` only matched `session.passport.user === userId`, but credential login (`/login` line 252) and passkey auth-verify (line 1307) store the database user id at `session.userId` and `session.user.id`. As a result, a deleted credential- or passkey-authenticated user kept a valid session cookie until natural 24h expiry — they continued to make authenticated requests after the admin deleted them.

The fix expands the per-session match to cover all three auth flows:

- **Credential login / passkey auth-verify** — match `session.userId` and `session.user.id` (numeric DB id).
- **Passport / Google OAuth** — match `session.passport.user.id` numerically, plus an **email** fallback. (`session.passport.user.id` is actually the Google profile id, not the DB id, so the original numeric check never matched OAuth sessions either; email matching closes that gap.)

Numeric ids are normalized through `Number()` for defensiveness against string/number drift in session storage. Email comparisons are lower-cased.

## Files changed

- `backend/src/routes/auth-extended.ts` — single block at the user-delete handler (~lines 1525–1585).

## Test plan

- [ ] Log in as user A via email/password. As admin, delete user A. Confirm A's existing cookie returns 401 on next authenticated request (previously it kept working).
- [ ] Repeat with passkey login.
- [ ] Repeat with Google OAuth login.
- [ ] Confirm an admin deleting a different user does not affect their own session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)