### PR TITLE
fix: gate /users with requireAdmin and stop leaking invite_token (ticket #535)

### DIFF
--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1429,17 +1429,21 @@ router.delete('/passkey/:id', requireAuth, async (req: Request, res: Response) =
 
 /**
  * List all users (admin only)
+ *
+ * Security note: requires `requireAdmin` — non-admin accounts must not be able
+ * to enumerate users. The response intentionally omits `invite_token`; admins
+ * who need an outstanding invite URL fetch it via
+ * `GET /users/:userId/invite-link` (one user at a time, admin-gated).
  */
-router.get('/users', requireAuth, (req: Request, res: Response) => {
+router.get('/users', requireAdmin, (req: Request, res: Response) => {
   try {
     const users = getAllUsers();
-    
+
     // Remove sensitive data and add computed fields
     const sanitizedUsers = users.map((user: User) => {
       // Determine display status based on user state
       let displayStatus = null;
-      let inviteToken = null;
-      
+
       if (user.status === 'invited') {
         // Check if invite has expired
         if (user.invite_expires_at) {
@@ -1452,11 +1456,8 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         } else {
           displayStatus = 'invited';
         }
-        
-        // Include invite token for invited/expired users (needed for copy link functionality)
-        inviteToken = user.invite_token;
       }
-      
+
       return {
         id: user.id,
         email: user.email,
@@ -1467,7 +1468,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         passkey_count: user.passkeys?.length || 0,
         is_active: user.is_active,
         status: displayStatus, // Only show status if invited or expired
-        invite_token: inviteToken, // Include for invited users
         created_at: user.created_at,
         last_login_at: user.last_login_at,
       };
@@ -1477,6 +1477,48 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
   } catch (err) {
     error('[AuthExtended] List users error:', err);
     res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+/**
+ * Fetch the outstanding invitation link for a single invited user (admin only).
+ *
+ * Carved out from `GET /users` so invite tokens are never returned in bulk list
+ * responses — admins must request them one at a time, and only admins can.
+ */
+router.get('/users/:userId/invite-link', requireAdmin, (req: Request, res: Response) => {
+  try {
+    const userId = parseInt(req.params.userId);
+    if (Number.isNaN(userId)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+
+    const user = getUserById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (user.status !== 'invited' || !user.invite_token) {
+      return res.status(400).json({ error: 'User does not have an outstanding invitation' });
+    }
+
+    let expired = false;
+    if (user.invite_expires_at) {
+      const expiresAt = new Date(user.invite_expires_at);
+      if (expiresAt < new Date()) {
+        expired = true;
+      }
+    }
+
+    return res.json({
+      inviteUrl: generateInvitationUrl(user.invite_token),
+      inviteToken: user.invite_token,
+      expired,
+      expiresAt: user.invite_expires_at || null,
+    });
+  } catch (err) {
+    error('[AuthExtended] Get invite link error:', err);
+    return res.status(500).json({ error: 'Failed to get invite link' });
   }
 });
 

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from 'react-i18next';
 import type { User } from "./types";
-import { getGravatarUrl, copyInvitationUrl } from "./utils";
+import { getGravatarUrl, userManagementAPI } from "./utils";
 import { error, info } from '../../../../../utils/logger';
 
 interface UserCardProps {
@@ -46,10 +46,14 @@ export const UserCard: React.FC<UserCardProps> = ({
   }
 
   const handleCopyInvite = async () => {
-    if (!user.invite_token) return;
-    
+    if (user.status !== "invited" && user.status !== "invite_expired") return;
+
     try {
-      await copyInvitationUrl(user.invite_token);
+      // Fetch the invite URL on demand from the admin-only endpoint instead of
+      // reading it from the bulk user list — the list response no longer
+      // exposes invite tokens.
+      const { inviteUrl } = await userManagementAPI.getInviteLink(user.id);
+      await navigator.clipboard.writeText(inviteUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -454,7 +458,7 @@ export const UserCard: React.FC<UserCardProps> = ({
       {currentUser && (
         <>
           {/* Invited/Expired Users - Show Copy Invite */}
-          {(user.status === "invited" || user.status === "invite_expired") && user.invite_token && (
+          {(user.status === "invited" || user.status === "invite_expired") && (
             <div
               style={{
                 display: "flex",

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
@@ -9,7 +9,6 @@ export interface User {
   auth_methods: string[];
   status?: string;
   picture?: string;
-  invite_token?: string | null;
 }
 
 export interface Passkey {

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
@@ -103,6 +103,25 @@ export const userManagementAPI = {
     return await res.json();
   },
 
+  async getInviteLink(userId: number) {
+    const res = await fetch(
+      `${API_URL}/api/auth-extended/users/${userId}/invite-link`,
+      { credentials: 'include' }
+    );
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to fetch invitation link');
+    }
+
+    return (await res.json()) as {
+      inviteUrl: string;
+      inviteToken: string;
+      expired: boolean;
+      expiresAt: string | null;
+    };
+  },
+
   async resendInvite(userId: number) {
     const res = await fetch(`${API_URL}/api/auth-extended/invite/resend/${userId}`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
Fixes a HIGH severity privilege escalation in `GET /api/auth-extended/users`: the route was gated by `requireAuth` instead of `requireAdmin`, so any authenticated user (including a viewer) could enumerate every account and read each invited user's `invite_token`. Those tokens are accepted by `GET /invite/:token` and `POST /invite/:token/complete`, so a viewer could claim an invited admin account before the legitimate invitee did.

- `GET /api/auth-extended/users` now requires admin and no longer returns `invite_token` in any list row.
- New admin-only `GET /api/auth-extended/users/:userId/invite-link` returns the invite URL (and token) for a single invited user, so the admin "Copy Invite Link" button keeps working without bulk-leaking tokens.
- Frontend `UserCard` now fetches the URL on demand via the new endpoint instead of reading `invite_token` off each list row, and the `User` TS type drops the now-removed `invite_token` field.

## Test plan
- [ ] As a viewer: `GET /api/auth-extended/users` returns 403.
- [ ] As an admin: `GET /api/auth-extended/users` returns 200, response rows have no `invite_token` field.
- [ ] As an admin: clicking "Copy Invite Link" on an invited user copies the correct `/invite/<token>` URL.
- [ ] As an admin: `GET /api/auth-extended/users/:userId/invite-link` returns 400 for active users and 200 for invited users.
- [ ] As a viewer: `GET /api/auth-extended/users/:userId/invite-link` returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)