### PR TITLE
fix: rename album filesystem before DB to avoid inconsistent state (ticket #504)

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1164,72 +1164,107 @@ router.patch("/:album/rename", requireManager, async (req: Request, res: Respons
       return;
     }
 
-    // Update database FIRST before touching filesystem
-    // This way if DB update fails, filesystem is unchanged
+    // Rename filesystem directories FIRST, tracking each successful rename
+    // so we can roll back on a later filesystem or database failure. This
+    // keeps the album consistent across DB and disk: either every rename
+    // sticks or none of them do.
+    const renamedPaths: Array<{ from: string; to: string }> = [];
+    const rollbackFsRenames = () => {
+      for (const { from, to } of [...renamedPaths].reverse()) {
+        try {
+          if (fs.existsSync(to)) {
+            fs.renameSync(to, from);
+          }
+        } catch (rollbackErr) {
+          error('[AlbumManagement] Failed to rollback filesystem rename', { from, to, err: rollbackErr });
+        }
+      }
+    };
+
+    const videoDir = req.app.get("videoDir");
+
+    try {
+      // Rename photos directory
+      fs.renameSync(oldAlbumPath, newAlbumPath);
+      renamedPaths.push({ from: oldAlbumPath, to: newAlbumPath });
+      info(`Renamed photos directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
+
+      // Rename optimized directories
+      for (const dir of ['thumbnail', 'modal', 'download']) {
+        const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
+        const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
+        if (fs.existsSync(oldOptimizedPath)) {
+          fs.renameSync(oldOptimizedPath, newOptimizedPath);
+          renamedPaths.push({ from: oldOptimizedPath, to: newOptimizedPath });
+          info(`Renamed optimized/${dir}: ${sanitizedOldName} -> ${sanitizedNewName}`);
+        }
+      }
+
+      // Rename video directory if it exists
+      if (videoDir) {
+        const oldVideoPath = path.join(videoDir, sanitizedOldName);
+        const newVideoPath = path.join(videoDir, sanitizedNewName);
+        if (fs.existsSync(oldVideoPath)) {
+          fs.renameSync(oldVideoPath, newVideoPath);
+          renamedPaths.push({ from: oldVideoPath, to: newVideoPath });
+          info(`Renamed video directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
+        }
+      }
+    } catch (fsErr) {
+      error('[AlbumManagement] Filesystem rename failed, rolling back partial renames', fsErr);
+      rollbackFsRenames();
+      res.status(500).json({ error: 'Failed to rename album directories' });
+      return;
+    }
+
+    // Update database after all filesystem renames have succeeded.
+    // If the transaction throws, roll back every filesystem rename so the
+    // album is left in its original on-disk state.
     const db = getDatabase();
-    
+
     // Start transaction with foreign keys temporarily disabled
     // This is needed because share_links has FK to albums(name) without ON UPDATE CASCADE
     const transaction = db.transaction(() => {
       // Temporarily disable foreign keys for this transaction
       db.pragma('foreign_keys = OFF');
-      
+
       // Update albums table
       const result = db.prepare(`
-        UPDATE albums 
+        UPDATE albums
         SET name = ?, updated_at = CURRENT_TIMESTAMP
         WHERE name = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       if (result.changes === 0) {
         throw new Error('Album not found in database');
       }
-      
+
       // Update image_metadata table
       db.prepare(`
-        UPDATE image_metadata 
+        UPDATE image_metadata
         SET album = ?, updated_at = CURRENT_TIMESTAMP
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       // Update share_links table
       db.prepare(`
-        UPDATE share_links 
+        UPDATE share_links
         SET album = ?
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       // Re-enable foreign keys
       db.pragma('foreign_keys = ON');
     });
-    
-    transaction();
-    info(`Updated database: ${sanitizedOldName} -> ${sanitizedNewName}`);
 
-    // Now rename filesystem directories
-    // Rename photos directory
-    fs.renameSync(oldAlbumPath, newAlbumPath);
-    info(`Renamed photos directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
-
-    // Rename optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
-      const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
-      const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
-      if (fs.existsSync(oldOptimizedPath)) {
-        fs.renameSync(oldOptimizedPath, newOptimizedPath);
-        info(`Renamed optimized/${dir}: ${sanitizedOldName} -> ${sanitizedNewName}`);
-      }
-    });
-
-    // Rename video directory if it exists
-    const videoDir = req.app.get("videoDir");
-    if (videoDir) {
-      const oldVideoPath = path.join(videoDir, sanitizedOldName);
-      const newVideoPath = path.join(videoDir, sanitizedNewName);
-      if (fs.existsSync(oldVideoPath)) {
-        fs.renameSync(oldVideoPath, newVideoPath);
-        info(`Renamed video directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
-      }
+    try {
+      transaction();
+      info(`Updated database: ${sanitizedOldName} -> ${sanitizedNewName}`);
+    } catch (dbErr) {
+      error('[AlbumManagement] Database transaction failed, rolling back filesystem renames', dbErr);
+      rollbackFsRenames();
+      res.status(500).json({ error: 'Failed to update database' });
+      return;
     }
 
     // Invalidate cache for both old and new album names


### PR DESCRIPTION
## Summary

- `PATCH /:album/rename` was committing the DB transaction before any `fs.renameSync`, so a filesystem rename failure (EBUSY / EACCES / ENOSPC / race) left the DB pointing at the new name while disk still had the old name — every subsequent read hit ENOENT with no rollback.
- Swapped the order to mirror the sibling `PUT /:album/rename`: filesystem first, then DB. Each fs rename is tracked so a partial failure rolls back prior renames; a DB transaction failure also rolls back every fs rename, leaving the album in its original on-disk state.
- Closes ticket #504.

## Test plan

- [ ] CI typecheck/build passes on the backend.
- [ ] Manual: rename an album via `PATCH /:album/rename` — DB and on-disk paths both move to the new name.
- [ ] Manual: simulate a fs rename failure (e.g. take a lock on `optimized/thumbnail/<album>` mid-rename) and confirm the photos directory and DB are reverted to the old name on 500.
- [ ] Manual: simulate a DB constraint failure during the transaction — confirm photos / optimized / video dirs are renamed back to the old name on 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)