### PR TITLE
Fix public EXIF endpoint leaking GPS coordinates (ticket #35)

### DIFF
--- a/backend/src/routes/albums.ts
+++ b/backend/src/routes/albums.ts
@@ -571,7 +571,7 @@ const servePhotoEXIF = async (req: Request, res: Response, albumName: string, fi
   // Sanitize inputs to prevent path traversal
   const sanitizedAlbum = sanitizePath(albumName);
   const sanitizedFilename = filename.replace(/[^a-zA-Z0-9_. -]/g, '');
-  
+
   if (!sanitizedAlbum || !sanitizedFilename) {
     res.status(400).json({ error: "Invalid album or filename" });
     return;
@@ -583,22 +583,58 @@ const servePhotoEXIF = async (req: Request, res: Response, albumName: string, fi
     return;
   }
 
+  // Check if user is authenticated (Passport or credentials)
+  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
+
+  // Check album published state — same gate as serveAlbumPhotos
+  const albumState = getAlbumState(sanitizedAlbum);
+
+  if (!albumState) {
+    res.status(404).json({ error: "Album not found" });
+    return;
+  }
+
+  if (!albumState.published && !isAuthenticated) {
+    res.status(403).json({ error: "Access denied" });
+    return;
+  }
+
   try {
     const photosDir = req.app.get("photosDir");
     const filePath = path.join(photosDir, sanitizedAlbum, sanitizedFilename);
-    
+
     // Check if file exists
     if (!fs.existsSync(filePath)) {
       res.status(404).json({ error: "Image not found" });
       return;
     }
 
-    // Extract EXIF data
-    const exif = await exifr.parse(filePath);
-    
+    // Extract EXIF data. For unauthenticated (public) callers, disable GPS
+    // parsing so coordinates never enter the response — privacy guarantee
+    // documented for public album variants. Authenticated admins still get
+    // the full payload.
+    const exif = isAuthenticated
+      ? await exifr.parse(filePath)
+      : await exifr.parse(filePath, { gps: false });
+
     if (!exif) {
       res.json({ message: "No EXIF data found" });
       return;
+    }
+
+    // Defense-in-depth: strip any residual GPS / coordinate keys for public
+    // responses in case exifr parses GPS via a different block (e.g. XMP).
+    if (!isAuthenticated && typeof exif === 'object') {
+      for (const key of Object.keys(exif)) {
+        if (
+          key.startsWith('GPS') ||
+          key === 'latitude' ||
+          key === 'longitude' ||
+          key === 'altitude'
+        ) {
+          delete (exif as Record<string, unknown>)[key];
+        }
+      }
     }
 
     res.json(exif);


### PR DESCRIPTION
## Summary

`GET /api/photos/:album/:filename/exif` was mounted with no auth gate and called `exifr.parse(filePath)` with default options, returning the full EXIF object — including `GPSLatitude`/`GPSLongitude`/`GPSAltitude` — to any visitor who knew (or could enumerate) a filename. This contradicts the documented privacy guarantee that public album variants strip GPS, and the published-state of the album wasn't even checked.

This change in `backend/src/routes/albums.ts`:

- Gates `servePhotoEXIF` on the same `isAuthenticated` + `albumState.published` check used by `serveAlbumPhotos`: 404 for missing albums, 403 for unpublished albums when the caller is not authenticated.
- For unauthenticated callers, parses with `{ gps: false }` so `exifr` never extracts GPS coordinates, and defensively strips any residual `GPS*` / `latitude` / `longitude` / `altitude` keys (defense-in-depth in case GPS leaks through a different block such as XMP).
- Authenticated admin callers continue to receive the full EXIF payload.

Closes ticket #35.

## Test plan

- [ ] CI passes on this PR.
- [ ] Hit `GET /api/photos/<published-album>/<file>/exif` unauthenticated → response contains EXIF but no `GPS*` / `latitude` / `longitude` / `altitude` keys.
- [ ] Hit the same endpoint authenticated as admin → full EXIF including GPS returned.
- [ ] Hit the endpoint for an unpublished album unauthenticated → 403.
- [ ] Hit the endpoint for an unknown album → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)