### PR TITLE
Batch merge #47: #538, #506, #505, #537, #502, #533, #536, #535, #503, #504, #35, #534, #32

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1164,72 +1164,107 @@ router.patch("/:album/rename", requireManager, async (req: Request, res: Respons
       return;
     }
 
-    // Update database FIRST before touching filesystem
-    // This way if DB update fails, filesystem is unchanged
+    // Rename filesystem directories FIRST, tracking each successful rename
+    // so we can roll back on a later filesystem or database failure. This
+    // keeps the album consistent across DB and disk: either every rename
+    // sticks or none of them do.
+    const renamedPaths: Array<{ from: string; to: string }> = [];
+    const rollbackFsRenames = () => {
+      for (const { from, to } of [...renamedPaths].reverse()) {
+        try {
+          if (fs.existsSync(to)) {
+            fs.renameSync(to, from);
+          }
+        } catch (rollbackErr) {
+          error('[AlbumManagement] Failed to rollback filesystem rename', { from, to, err: rollbackErr });
+        }
+      }
+    };
+
+    const videoDir = req.app.get("videoDir");
+
+    try {
+      // Rename photos directory
+      fs.renameSync(oldAlbumPath, newAlbumPath);
+      renamedPaths.push({ from: oldAlbumPath, to: newAlbumPath });
+      info(`Renamed photos directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
+
+      // Rename optimized directories
+      for (const dir of ['thumbnail', 'modal', 'download']) {
+        const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
+        const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
+        if (fs.existsSync(oldOptimizedPath)) {
+          fs.renameSync(oldOptimizedPath, newOptimizedPath);
+          renamedPaths.push({ from: oldOptimizedPath, to: newOptimizedPath });
+          info(`Renamed optimized/${dir}: ${sanitizedOldName} -> ${sanitizedNewName}`);
+        }
+      }
+
+      // Rename video directory if it exists
+      if (videoDir) {
+        const oldVideoPath = path.join(videoDir, sanitizedOldName);
+        const newVideoPath = path.join(videoDir, sanitizedNewName);
+        if (fs.existsSync(oldVideoPath)) {
+          fs.renameSync(oldVideoPath, newVideoPath);
+          renamedPaths.push({ from: oldVideoPath, to: newVideoPath });
+          info(`Renamed video directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
+        }
+      }
+    } catch (fsErr) {
+      error('[AlbumManagement] Filesystem rename failed, rolling back partial renames', fsErr);
+      rollbackFsRenames();
+      res.status(500).json({ error: 'Failed to rename album directories' });
+      return;
+    }
+
+    // Update database after all filesystem renames have succeeded.
+    // If the transaction throws, roll back every filesystem rename so the
+    // album is left in its original on-disk state.
     const db = getDatabase();
-    
+
     // Start transaction with foreign keys temporarily disabled
     // This is needed because share_links has FK to albums(name) without ON UPDATE CASCADE
     const transaction = db.transaction(() => {
       // Temporarily disable foreign keys for this transaction
       db.pragma('foreign_keys = OFF');
-      
+
       // Update albums table
       const result = db.prepare(`
-        UPDATE albums 
+        UPDATE albums
         SET name = ?, updated_at = CURRENT_TIMESTAMP
         WHERE name = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       if (result.changes === 0) {
         throw new Error('Album not found in database');
       }
-      
+
       // Update image_metadata table
       db.prepare(`
-        UPDATE image_metadata 
+        UPDATE image_metadata
         SET album = ?, updated_at = CURRENT_TIMESTAMP
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       // Update share_links table
       db.prepare(`
-        UPDATE share_links 
+        UPDATE share_links
         SET album = ?
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       // Re-enable foreign keys
       db.pragma('foreign_keys = ON');
     });
-    
-    transaction();
-    info(`Updated database: ${sanitizedOldName} -> ${sanitizedNewName}`);
 
-    // Now rename filesystem directories
-    // Rename photos directory
-    fs.renameSync(oldAlbumPath, newAlbumPath);
-    info(`Renamed photos directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
-
-    // Rename optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
-      const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
-      const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
-      if (fs.existsSync(oldOptimizedPath)) {
-        fs.renameSync(oldOptimizedPath, newOptimizedPath);
-        info(`Renamed optimized/${dir}: ${sanitizedOldName} -> ${sanitizedNewName}`);
-      }
-    });
-
-    // Rename video directory if it exists
-    const videoDir = req.app.get("videoDir");
-    if (videoDir) {
-      const oldVideoPath = path.join(videoDir, sanitizedOldName);
-      const newVideoPath = path.join(videoDir, sanitizedNewName);
-      if (fs.existsSync(oldVideoPath)) {
-        fs.renameSync(oldVideoPath, newVideoPath);
-        info(`Renamed video directory: ${sanitizedOldName} -> ${sanitizedNewName}`);
-      }
+    try {
+      transaction();
+      info(`Updated database: ${sanitizedOldName} -> ${sanitizedNewName}`);
+    } catch (dbErr) {
+      error('[AlbumManagement] Database transaction failed, rolling back filesystem renames', dbErr);
+      rollbackFsRenames();
+      res.status(500).json({ error: 'Failed to update database' });
+      return;
     }
 
     // Invalidate cache for both old and new album names

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1168,39 +1168,35 @@ router.patch("/:album/rename", requireManager, async (req: Request, res: Respons
     // This way if DB update fails, filesystem is unchanged
     const db = getDatabase();
     
-    // Start transaction with foreign keys temporarily disabled
-    // This is needed because share_links has FK to albums(name) without ON UPDATE CASCADE
+    // share_links.album has ON UPDATE CASCADE (see database.ts), so renaming
+    // the album row cascades automatically. The explicit share_links UPDATE
+    // below is kept as a safety net for older databases that pre-date the
+    // migrate-share-links-cascade.js migration.
     const transaction = db.transaction(() => {
-      // Temporarily disable foreign keys for this transaction
-      db.pragma('foreign_keys = OFF');
-      
       // Update albums table
       const result = db.prepare(`
-        UPDATE albums 
+        UPDATE albums
         SET name = ?, updated_at = CURRENT_TIMESTAMP
         WHERE name = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       if (result.changes === 0) {
         throw new Error('Album not found in database');
       }
-      
+
       // Update image_metadata table
       db.prepare(`
-        UPDATE image_metadata 
+        UPDATE image_metadata
         SET album = ?, updated_at = CURRENT_TIMESTAMP
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
+
       // Update share_links table
       db.prepare(`
-        UPDATE share_links 
+        UPDATE share_links
         SET album = ?
         WHERE album = ?
       `).run(sanitizedNewName, sanitizedOldName);
-      
-      // Re-enable foreign keys
-      db.pragma('foreign_keys = ON');
     });
     
     transaction();

--- a/backend/src/routes/albums.ts
+++ b/backend/src/routes/albums.ts
@@ -571,7 +571,7 @@ const servePhotoEXIF = async (req: Request, res: Response, albumName: string, fi
   // Sanitize inputs to prevent path traversal
   const sanitizedAlbum = sanitizePath(albumName);
   const sanitizedFilename = filename.replace(/[^a-zA-Z0-9_. -]/g, '');
-  
+
   if (!sanitizedAlbum || !sanitizedFilename) {
     res.status(400).json({ error: "Invalid album or filename" });
     return;
@@ -583,22 +583,58 @@ const servePhotoEXIF = async (req: Request, res: Response, albumName: string, fi
     return;
   }
 
+  // Check if user is authenticated (Passport or credentials)
+  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
+
+  // Check album published state — same gate as serveAlbumPhotos
+  const albumState = getAlbumState(sanitizedAlbum);
+
+  if (!albumState) {
+    res.status(404).json({ error: "Album not found" });
+    return;
+  }
+
+  if (!albumState.published && !isAuthenticated) {
+    res.status(403).json({ error: "Access denied" });
+    return;
+  }
+
   try {
     const photosDir = req.app.get("photosDir");
     const filePath = path.join(photosDir, sanitizedAlbum, sanitizedFilename);
-    
+
     // Check if file exists
     if (!fs.existsSync(filePath)) {
       res.status(404).json({ error: "Image not found" });
       return;
     }
 
-    // Extract EXIF data
-    const exif = await exifr.parse(filePath);
-    
+    // Extract EXIF data. For unauthenticated (public) callers, disable GPS
+    // parsing so coordinates never enter the response — privacy guarantee
+    // documented for public album variants. Authenticated admins still get
+    // the full payload.
+    const exif = isAuthenticated
+      ? await exifr.parse(filePath)
+      : await exifr.parse(filePath, { gps: false });
+
     if (!exif) {
       res.json({ message: "No EXIF data found" });
       return;
+    }
+
+    // Defense-in-depth: strip any residual GPS / coordinate keys for public
+    // responses in case exifr parses GPS via a different block (e.g. XMP).
+    if (!isAuthenticated && typeof exif === 'object') {
+      for (const key of Object.keys(exif)) {
+        if (
+          key.startsWith('GPS') ||
+          key === 'latitude' ||
+          key === 'longitude' ||
+          key === 'altitude'
+        ) {
+          delete (exif as Record<string, unknown>)[key];
+        }
+      }
     }
 
     res.json(exif);

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1430,24 +1430,28 @@ router.delete('/passkey/:id', requireAuth, async (req: Request, res: Response) =
 /**
  * List all users (admin only)
  *
- * SECURITY: This endpoint returns `invite_token` for users in the `invited`
- * state so the admin UI can render a "Copy Invite Link" affordance. The
+ * SECURITY: This endpoint MUST NOT return `invite_token` for any user. The
  * invite token is sufficient on its own to complete the invitation and take
  * over the invited account (see POST /invite/:token/complete, which is
- * unauthenticated by design). It MUST therefore stay gated by requireAdmin —
- * downgrading this to requireAuth leaks invite tokens to viewers/managers and
- * creates a direct privilege-escalation path.
+ * unauthenticated by design), so disclosing it on every page-load of the
+ * admin user list — even to admins — needlessly widens the blast radius of a
+ * compromised admin session and blocks future token-rotation / one-time-use
+ * controls. Admins fetch the token on demand via
+ * GET /users/:userId/invite-link when they explicitly click "Copy Link".
+ *
+ * Endpoint also stays gated by requireAdmin — downgrading to requireAuth
+ * would expose user metadata (roles, auth methods, MFA state, etc.) to
+ * viewers/managers.
  */
 router.get('/users', requireAdmin, (req: Request, res: Response) => {
   try {
     const users = getAllUsers();
-    
+
     // Remove sensitive data and add computed fields
     const sanitizedUsers = users.map((user: User) => {
       // Determine display status based on user state
       let displayStatus = null;
-      let inviteToken = null;
-      
+
       if (user.status === 'invited') {
         // Check if invite has expired
         if (user.invite_expires_at) {
@@ -1460,11 +1464,8 @@ router.get('/users', requireAdmin, (req: Request, res: Response) => {
         } else {
           displayStatus = 'invited';
         }
-        
-        // Include invite token for invited/expired users (needed for copy link functionality)
-        inviteToken = user.invite_token;
       }
-      
+
       return {
         id: user.id,
         email: user.email,
@@ -1475,7 +1476,7 @@ router.get('/users', requireAdmin, (req: Request, res: Response) => {
         passkey_count: user.passkeys?.length || 0,
         is_active: user.is_active,
         status: displayStatus, // Only show status if invited or expired
-        invite_token: inviteToken, // Include for invited users
+        // invite_token is intentionally NOT returned here — see SECURITY note above.
         created_at: user.created_at,
         last_login_at: user.last_login_at,
       };
@@ -1485,6 +1486,36 @@ router.get('/users', requireAdmin, (req: Request, res: Response) => {
   } catch (err) {
     error('[AuthExtended] List users error:', err);
     res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+/**
+ * Fetch the invite link/token for a single invited user (admin only).
+ *
+ * Separated from GET /users so that the raw `invite_token` is only disclosed
+ * in response to an explicit admin action (clicking "Copy Invite Link"),
+ * rather than being baked into every list response. Returns 404 if the user
+ * does not exist or is not in an invited/expired state.
+ */
+router.get('/users/:userId/invite-link', requireAdmin, (req: Request, res: Response) => {
+  try {
+    const userId = parseInt(req.params.userId);
+    if (isNaN(userId)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+
+    const user = getUserById(userId);
+    if (!user || user.status !== 'invited' || !user.invite_token) {
+      return res.status(404).json({ error: 'No active invite for this user' });
+    }
+
+    return res.json({
+      invite_token: user.invite_token,
+      invite_expires_at: user.invite_expires_at,
+    });
+  } catch (err) {
+    error('[AuthExtended] Fetch invite link error:', err);
+    return res.status(500).json({ error: 'Failed to fetch invite link' });
   }
 });
 

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -98,6 +98,78 @@ function getUserIdFromRequest(req: Request): number | null {
 // Store temporary challenges in memory (in production, use Redis or session store)
 const challenges = new Map<string, { challenge: string; userId?: number; user?: User; expires: number }>();
 
+/**
+ * Verify a sensitive-action re-authentication proof.
+ *
+ * Accepts either a valid password (when the user has a `password_hash`) or a
+ * fresh passkey assertion bound to the user's own credential. This closes a
+ * bypass where users without a password (Google OAuth / passkey-only) could
+ * pass through `if (user.password_hash && !verifyPassword(...))` because the
+ * `&&` short-circuits to `false` when `password_hash` is empty, allowing MFA
+ * to be disabled or backup codes to be regenerated with no proof.
+ */
+async function verifyReauth(
+  user: User,
+  body: any
+): Promise<{ ok: true } | { ok: false; status: number; reason: string }> {
+  const { password, passkeyCredential, passkeySessionId } = body || {};
+
+  // Path 1: passkey assertion (preferred when supplied — works for every user
+  // with at least one registered passkey, including OAuth-only accounts).
+  if (passkeyCredential && passkeySessionId) {
+    const stored = challenges.get(`passkey-auth-${passkeySessionId}`);
+    if (!stored || stored.expires < Date.now()) {
+      return { ok: false, status: 400, reason: 'Invalid or expired challenge' };
+    }
+
+    const result = getPasskeyByCredentialId(passkeyCredential.id);
+    // The credential MUST belong to the currently authenticated user — never
+    // accept a passkey owned by someone else as proof of re-authentication.
+    if (!result || result.user.id !== user.id) {
+      return { ok: false, status: 401, reason: 'Passkey verification failed' };
+    }
+
+    try {
+      const verification = await verifyPasskeyAuthentication(
+        passkeyCredential,
+        stored.challenge,
+        result.passkey.credentialPublicKey,
+        result.passkey.counter
+      );
+      if (!verification.verified) {
+        return { ok: false, status: 401, reason: 'Passkey verification failed' };
+      }
+      // Consume the challenge and bump the credential counter so the assertion
+      // cannot be replayed.
+      updatePasskeyCounter(
+        user.id,
+        result.passkey.id,
+        verification.authenticationInfo.newCounter
+      );
+      challenges.delete(`passkey-auth-${passkeySessionId}`);
+      return { ok: true };
+    } catch (err) {
+      error('[AuthExtended] Re-auth passkey verification error:', err);
+      return { ok: false, status: 401, reason: 'Passkey verification failed' };
+    }
+  }
+
+  // Path 2: password (only valid when the account actually has one).
+  if (user.password_hash) {
+    if (!password || !verifyPassword(user, password)) {
+      return { ok: false, status: 401, reason: 'Invalid password' };
+    }
+    return { ok: true };
+  }
+
+  // No password on the account and no passkey assertion — reject.
+  return {
+    ok: false,
+    status: 401,
+    reason: 'Re-authentication required. Provide a passkey assertion to continue.',
+  };
+}
+
 // Clean up expired challenges every 5 minutes
 setInterval(() => {
   const now = Date.now();
@@ -1020,16 +1092,18 @@ router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => 
     if (!userId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
-    const { password } = req.body;
 
     const user = getUserById(userId);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    // Verify password before disabling MFA
-    if (user.password_hash && !verifyPassword(user, password)) {
-      return res.status(401).json({ error: 'Invalid password' });
+    // Require a fresh re-auth proof (password OR passkey assertion). Without
+    // this, users who authenticate via Google OAuth or passkey only (no
+    // `password_hash`) could disable MFA with no second-factor check.
+    const reauth = await verifyReauth(user, req.body);
+    if (!reauth.ok) {
+      return res.status(reauth.status).json({ error: reauth.reason });
     }
 
     disableMFA(userId);
@@ -1069,16 +1143,18 @@ router.post('/mfa/backup-codes', requireAuth, async (req: Request, res: Response
     if (!userId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
-    const { password } = req.body;
 
     const user = getUserById(userId);
     if (!user || !user.mfa_enabled) {
       return res.status(400).json({ error: 'MFA is not enabled' });
     }
 
-    // Verify password
-    if (user.password_hash && !verifyPassword(user, password)) {
-      return res.status(401).json({ error: 'Invalid password' });
+    // Require a fresh re-auth proof (password OR passkey assertion). Without
+    // this, users without a `password_hash` could mint new backup codes from a
+    // hijacked Google session and defeat the second factor.
+    const reauth = await verifyReauth(user, req.body);
+    if (!reauth.ok) {
+      return res.status(reauth.status).json({ error: reauth.reason });
     }
 
     // Generate new backup codes

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1531,11 +1531,48 @@ router.delete('/users/:userId', requireAdmin, async (req: Request, res: Response
           return;
         }
         
-        // Destroy sessions belonging to the deleted user
+        // Destroy sessions belonging to the deleted user.
+        // Sessions can be created by three auth flows, each storing the user
+        // identifier in a different shape:
+        //   - credential login (/login):           session.userId = <db id>
+        //   - passkey auth-verify:                  session.userId = <db id>
+        //                                           session.user.id  = <db id>
+        //   - Passport / Google OAuth:             session.passport.user = { id: googleProfileId, email, ... }
+        // Match all of them. Numeric ids are normalized via Number() in case a
+        // session store serialized ids as strings; OAuth sessions are matched
+        // by email since session.passport.user.id is the Google profile id,
+        // not the database user id.
         if (sessions) {
+          const targetId = Number(userId);
+          const targetEmail = targetUser.email ? targetUser.email.toLowerCase() : null;
           Object.keys(sessions).forEach((sid) => {
             const session = sessions[sid];
-            if (session?.passport?.user === userId) {
+            if (!session) return;
+
+            const credentialUserId = session.userId !== undefined ? Number(session.userId) : NaN;
+            const sessionUserObjId = session.user?.id !== undefined ? Number(session.user.id) : NaN;
+            const passportUser = session.passport?.user;
+            const passportUserId =
+              passportUser && typeof passportUser === 'object' && passportUser.id !== undefined
+                ? Number(passportUser.id)
+                : typeof passportUser === 'number'
+                  ? passportUser
+                  : NaN;
+            const passportEmail =
+              passportUser && typeof passportUser === 'object' && typeof passportUser.email === 'string'
+                ? passportUser.email.toLowerCase()
+                : null;
+            const sessionUserEmail =
+              typeof session.user?.email === 'string' ? session.user.email.toLowerCase() : null;
+
+            const belongsToDeletedUser =
+              credentialUserId === targetId ||
+              sessionUserObjId === targetId ||
+              passportUserId === targetId ||
+              (targetEmail !== null &&
+                (passportEmail === targetEmail || sessionUserEmail === targetEmail));
+
+            if (belongsToDeletedUser) {
               sessionStore.destroy(sid, (destroyErr) => {
                 if (destroyErr) {
                   error(`Failed to destroy session ${sid}:`, destroyErr);

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1429,8 +1429,16 @@ router.delete('/passkey/:id', requireAuth, async (req: Request, res: Response) =
 
 /**
  * List all users (admin only)
+ *
+ * SECURITY: This endpoint returns `invite_token` for users in the `invited`
+ * state so the admin UI can render a "Copy Invite Link" affordance. The
+ * invite token is sufficient on its own to complete the invitation and take
+ * over the invited account (see POST /invite/:token/complete, which is
+ * unauthenticated by design). It MUST therefore stay gated by requireAdmin —
+ * downgrading this to requireAuth leaks invite tokens to viewers/managers and
+ * creates a direct privilege-escalation path.
  */
-router.get('/users', requireAuth, (req: Request, res: Response) => {
+router.get('/users', requireAdmin, (req: Request, res: Response) => {
   try {
     const users = getAllUsers();
     

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1429,17 +1429,21 @@ router.delete('/passkey/:id', requireAuth, async (req: Request, res: Response) =
 
 /**
  * List all users (admin only)
+ *
+ * Security note: requires `requireAdmin` — non-admin accounts must not be able
+ * to enumerate users. The response intentionally omits `invite_token`; admins
+ * who need an outstanding invite URL fetch it via
+ * `GET /users/:userId/invite-link` (one user at a time, admin-gated).
  */
-router.get('/users', requireAuth, (req: Request, res: Response) => {
+router.get('/users', requireAdmin, (req: Request, res: Response) => {
   try {
     const users = getAllUsers();
-    
+
     // Remove sensitive data and add computed fields
     const sanitizedUsers = users.map((user: User) => {
       // Determine display status based on user state
       let displayStatus = null;
-      let inviteToken = null;
-      
+
       if (user.status === 'invited') {
         // Check if invite has expired
         if (user.invite_expires_at) {
@@ -1452,11 +1456,8 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         } else {
           displayStatus = 'invited';
         }
-        
-        // Include invite token for invited/expired users (needed for copy link functionality)
-        inviteToken = user.invite_token;
       }
-      
+
       return {
         id: user.id,
         email: user.email,
@@ -1467,7 +1468,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         passkey_count: user.passkeys?.length || 0,
         is_active: user.is_active,
         status: displayStatus, // Only show status if invited or expired
-        invite_token: inviteToken, // Include for invited users
         created_at: user.created_at,
         last_login_at: user.last_login_at,
       };
@@ -1477,6 +1477,48 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
   } catch (err) {
     error('[AuthExtended] List users error:', err);
     res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+/**
+ * Fetch the outstanding invitation link for a single invited user (admin only).
+ *
+ * Carved out from `GET /users` so invite tokens are never returned in bulk list
+ * responses — admins must request them one at a time, and only admins can.
+ */
+router.get('/users/:userId/invite-link', requireAdmin, (req: Request, res: Response) => {
+  try {
+    const userId = parseInt(req.params.userId);
+    if (Number.isNaN(userId)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+
+    const user = getUserById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (user.status !== 'invited' || !user.invite_token) {
+      return res.status(400).json({ error: 'User does not have an outstanding invitation' });
+    }
+
+    let expired = false;
+    if (user.invite_expires_at) {
+      const expiresAt = new Date(user.invite_expires_at);
+      if (expiresAt < new Date()) {
+        expired = true;
+      }
+    }
+
+    return res.json({
+      inviteUrl: generateInvitationUrl(user.invite_token),
+      inviteToken: user.invite_token,
+      expired,
+      expiresAt: user.invite_expires_at || null,
+    });
+  } catch (err) {
+    error('[AuthExtended] Get invite link error:', err);
+    return res.status(500).json({ error: 'Failed to get invite link' });
   }
 });
 

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -51,6 +51,93 @@ const CONFIG_PATH = path.join(DATA_DIR, "config.json");
 const LOGS_DIR = path.join(DATA_DIR, "logs");
 
 /**
+ * Sentinel string returned in GET /api/config in place of any non-empty
+ * sensitive value. The PUT handler treats this exact string as "leave the
+ * stored value alone", restoring the on-disk value before persisting. This
+ * keeps plaintext secrets off the wire (and out of browser memory / dev
+ * tools) while preserving the admin-editor round-trip.
+ */
+const SECRET_PLACEHOLDER = "__SECRET_UNCHANGED__";
+
+/**
+ * Dot-notation paths to fields whose plaintext values must never appear
+ * in API responses. Paths that don't exist in a given config are silently
+ * skipped, so adding new sensitive fields here is safe.
+ */
+const SENSITIVE_CONFIG_PATHS: readonly string[] = [
+  "environment.auth.sessionSecret",
+  "environment.auth.google.clientSecret",
+  "analytics.openobserve.password",
+  "openai.apiKey",
+  "pushNotifications.vapidPrivateKey",
+  "email.smtp.auth.user",
+  "email.smtp.auth.pass",
+];
+
+function getDeep(obj: any, dottedPath: string): any {
+  const parts = dottedPath.split(".");
+  let cursor = obj;
+  for (const key of parts) {
+    if (cursor === null || cursor === undefined || typeof cursor !== "object") {
+      return undefined;
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+function setDeep(obj: any, dottedPath: string, value: any): void {
+  const parts = dottedPath.split(".");
+  let cursor = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    if (
+      cursor[key] === null ||
+      cursor[key] === undefined ||
+      typeof cursor[key] !== "object"
+    ) {
+      // Path doesn't exist in target — don't materialize it.
+      return;
+    }
+    cursor = cursor[key];
+  }
+  cursor[parts[parts.length - 1]] = value;
+}
+
+/**
+ * Returns a deep clone of the config with every non-empty sensitive field
+ * replaced by SECRET_PLACEHOLDER. Empty strings (and absent fields) are
+ * preserved so the UI can distinguish "not configured" from "configured
+ * but masked".
+ */
+function maskSensitiveFields(config: any): any {
+  const masked = JSON.parse(JSON.stringify(config));
+  for (const dottedPath of SENSITIVE_CONFIG_PATHS) {
+    const value = getDeep(masked, dottedPath);
+    if (typeof value === "string" && value.length > 0) {
+      setDeep(masked, dottedPath, SECRET_PLACEHOLDER);
+    }
+  }
+  return masked;
+}
+
+/**
+ * Mutates `newConfig` in place: any sensitive field whose value is exactly
+ * SECRET_PLACEHOLDER (i.e. the admin saved the form without rotating that
+ * secret) is rewritten to the value currently on disk. Posting an explicit
+ * empty string still clears the secret — admin intent is preserved.
+ */
+function restoreSensitiveFields(newConfig: any, currentConfig: any): void {
+  for (const dottedPath of SENSITIVE_CONFIG_PATHS) {
+    const submitted = getDeep(newConfig, dottedPath);
+    if (submitted === SECRET_PLACEHOLDER) {
+      const stored = getDeep(currentConfig, dottedPath);
+      setDeep(newConfig, dottedPath, stored);
+    }
+  }
+}
+
+/**
  * GET /api/config/runtime
  * Get runtime configuration for frontend (public endpoint for OOBE support)
  * Returns API URL auto-detected from request headers when config doesn't exist
@@ -112,11 +199,11 @@ router.get("/", requireAdmin, (req, res) => {
     const configData = fs.readFileSync(CONFIG_PATH, "utf8");
     const config = JSON.parse(configData);
 
-    // Return full config for admin to edit. Admins legitimately need the
-    // existing secret values in the editor; the PUT handler performs a
-    // shallow merge of whatever the client posts back, so masking values
-    // here would cause saves to silently overwrite stored secrets.
-    res.json(config);
+    // Mask credentials before sending to the admin UI. The PUT handler
+    // recognises SECRET_PLACEHOLDER and restores the on-disk value, so the
+    // editor round-trip works without exposing plaintext secrets to the
+    // browser, devtools, or any proxy along the way.
+    res.json(maskSensitiveFields(config));
   } catch (err) {
     error("[Config] Failed to read config:", err);
     res.status(500).json({ error: "Failed to read configuration" });
@@ -184,6 +271,11 @@ router.put("/", requireAdmin, express.json(), async (req, res) => {
     // Read current config to preserve structure
     const currentConfigData = fs.readFileSync(CONFIG_PATH, "utf8");
     const currentConfig = JSON.parse(currentConfigData);
+
+    // Any sensitive field the client posted back as the placeholder means
+    // "I didn't touch this" — substitute the current on-disk value before
+    // merging so masked secrets aren't overwritten with the sentinel.
+    restoreSensitiveFields(newConfig, currentConfig);
 
     // Merge new config with current (preserving any fields not sent)
     const updatedConfig = {

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { csrfProtection } from "../security.js";
-import { requireAuth, requireAdmin } from "../auth/middleware.js";
+import { requireAdmin } from "../auth/middleware.js";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendNotificationToUser } from '../push-notifications.js';
 import { translateNotification } from '../i18n-backend.js';
@@ -102,15 +102,20 @@ router.use(csrfProtection);
 
 /**
  * GET /api/config
- * Get current configuration (excluding sensitive fields)
+ * Get current configuration (admin only — payload contains plaintext
+ * secrets such as session/OAuth/OpenAI/VAPID/SMTP/OpenObserve credentials
+ * and the authorized-email allowlist, which must never reach viewers or
+ * managers).
  */
-router.get("/", requireAuth, (req, res) => {
+router.get("/", requireAdmin, (req, res) => {
   try {
     const configData = fs.readFileSync(CONFIG_PATH, "utf8");
     const config = JSON.parse(configData);
 
-    // Return full config for admin to edit
-    // (sensitive fields will be masked on frontend if needed)
+    // Return full config for admin to edit. Admins legitimately need the
+    // existing secret values in the editor; the PUT handler performs a
+    // shallow merge of whatever the client posts back, so masking values
+    // here would cause saves to silently overwrite stored secrets.
     res.json(config);
   } catch (err) {
     error("[Config] Failed to read config:", err);

--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -3,7 +3,7 @@
  * Handles initial setup and configuration for first-time users
  */
 
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -16,8 +16,38 @@ import { pipeline } from "stream/promises";
 import { createGunzip } from "zlib";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendInstallationEvent } from '../utils/installation-analytics.js';
+import { getConfigExists } from '../config.js';
 
 const router = Router();
+
+/**
+ * Guard for OOBE-only endpoints. Once config.json exists, the initial setup
+ * has already been performed and these endpoints must refuse further calls —
+ * otherwise an unauthenticated attacker could overwrite the session secret,
+ * authorized emails, OAuth credentials, allowed origins/hosts, and provision
+ * a new admin user (full account takeover). See ticket #533.
+ *
+ * The post-OOBE equivalents live behind authenticated routes (e.g.
+ * /api/branding/upload-avatar).
+ */
+function refuseIfSetupComplete(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (getConfigExists()) {
+    warn(
+      `[Setup] Refusing ${req.method} ${req.path} — setup has already completed. ` +
+      `Source IP: ${req.ip || req.socket.remoteAddress}`
+    );
+    res.status(403).json({
+      error: "Setup has already completed. This endpoint is disabled.",
+      setupComplete: true,
+    });
+    return;
+  }
+  next();
+}
 
 // Configure multer for avatar uploads
 const upload = multer({
@@ -246,6 +276,7 @@ router.get("/status", async (req: Request, res: Response): Promise<void> => {
  */
 router.post(
   "/initialize",
+  refuseIfSetupComplete,
   async (req: Request, res: Response): Promise<void> => {
     try {
       const {
@@ -755,6 +786,7 @@ router.post(
  */
 router.post(
   "/upload-avatar",
+  refuseIfSetupComplete,
   upload.single("avatar"),
   async (req: Request, res: Response): Promise<void> => {
     try {

--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -8,7 +8,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { requireAuth } from '../auth/middleware.js';
+import { requireAdmin } from '../auth/middleware.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -17,7 +17,7 @@ const __dirname = path.dirname(__filename);
 const router = Router();
 
 // Restart endpoint - triggers container restart or PM2 restart
-router.post('/restart', requireAuth, (req, res) => {
+router.post('/restart', requireAdmin, (req, res) => {
   try {
     // Get user info for logging
     const userId = (req.session as any)?.userId;

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -180,9 +180,30 @@ export function csrfProtection(req: any, res: any, next: any) {
   if (origin) {
     // Get dynamic allowed origins (includes config.json values)
     const allowedOrigins = getAllowedOrigins();
-    
-    // Check exact match first
-    let isAllowedOrigin = allowedOrigins.some((allowed: string) => origin.startsWith(allowed));
+
+    // Strict origin equality. Previously this used `origin.startsWith(allowed)`,
+    // which accepted a malicious origin like `https://www.example.com.attacker.com`
+    // when `https://www.example.com` was allowed. Parse both sides and compare
+    // the canonical `URL.origin` (scheme + host + port) so confusable suffixes
+    // can't bypass the check.
+    let normalizedOrigin: string | null = null;
+    try {
+      normalizedOrigin = new URL(origin).origin;
+    } catch (e) {
+      // Origin header was not a valid URL — reject below.
+    }
+
+    let isAllowedOrigin = false;
+    if (normalizedOrigin) {
+      isAllowedOrigin = allowedOrigins.some((allowed: string) => {
+        try {
+          return new URL(allowed).origin === normalizedOrigin;
+        } catch (e) {
+          warn('[CSRF] Skipping malformed allowed origin:', allowed);
+          return false;
+        }
+      });
+    }
     
     // If not in allowed list, check for localhost
     if (!isAllowedOrigin) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -766,8 +766,8 @@ i18nInitPromise.then(() => {
           error("[Startup] ✗ Failed to generate static JSON:", result.error);
         }
       })
-      .catch((error) => {
-        error("[Startup] ✗ Failed to generate static JSON:", error);
+      .catch((err) => {
+        error("[Startup] ✗ Failed to generate static JSON:", err);
       });
   }
   });

--- a/backend/src/utils/video-processor.ts
+++ b/backend/src/utils/video-processor.ts
@@ -96,6 +96,11 @@ export async function getVideoMetadata(videoPath: string): Promise<VideoMetadata
         reject(new Error(`Failed to parse ffprobe output: ${err}`));
       }
     });
+
+    ffprobe.on('error', (err) => {
+      error('[VideoProcessor] Failed to spawn ffprobe:', err);
+      reject(new Error(`Failed to spawn ffprobe: ${err.message}`));
+    });
   });
 }
 
@@ -252,6 +257,11 @@ export async function rotateVideo(
         if (onProgress) onProgress(100);
         resolve();
       }
+    });
+
+    ffmpeg.on('error', (err) => {
+      error('[VideoProcessor] Failed to spawn ffmpeg for rotation:', err);
+      reject(new Error(`Failed to spawn ffmpeg for rotation: ${err.message}`));
     });
   });
 }
@@ -475,6 +485,11 @@ export async function generateHLS(
         resolve();
       }
     });
+
+    ffmpeg.on('error', (err) => {
+      error(`[VideoProcessor] Failed to spawn ffmpeg for ${resolution.name} HLS generation:`, err);
+      reject(new Error(`Failed to spawn ffmpeg for HLS generation: ${err.message}`));
+    });
   });
 }
 
@@ -515,6 +530,11 @@ export async function extractThumbnail(
         info(`[VideoProcessor] ${size}px thumbnail extracted successfully`);
         resolve();
       }
+    });
+
+    ffmpeg.on('error', (err) => {
+      error('[VideoProcessor] Failed to spawn ffmpeg for thumbnail extraction:', err);
+      reject(new Error(`Failed to spawn ffmpeg for thumbnail extraction: ${err.message}`));
     });
   });
 }

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from 'react-i18next';
 import type { User } from "./types";
-import { getGravatarUrl, copyInvitationUrl } from "./utils";
+import { getGravatarUrl, copyInvitationUrl, userManagementAPI } from "./utils";
 import { error, info } from '../../../../../utils/logger';
 
 interface UserCardProps {
@@ -46,10 +46,11 @@ export const UserCard: React.FC<UserCardProps> = ({
   }
 
   const handleCopyInvite = async () => {
-    if (!user.invite_token) return;
-    
     try {
-      await copyInvitationUrl(user.invite_token);
+      // Fetch the invite token on-demand from the dedicated admin-only endpoint.
+      // The list response intentionally omits invite_token to limit exposure.
+      const inviteToken = await userManagementAPI.fetchInviteLink(user.id);
+      await copyInvitationUrl(inviteToken);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -453,8 +454,10 @@ export const UserCard: React.FC<UserCardProps> = ({
       {/* User Actions */}
       {currentUser && (
         <>
-          {/* Invited/Expired Users - Show Copy Invite */}
-          {(user.status === "invited" || user.status === "invite_expired") && user.invite_token && (
+          {/* Invited/Expired Users - Show Copy Invite. The token itself is
+              fetched on-demand from a dedicated admin-only endpoint when the
+              admin clicks Copy, so the list response no longer carries it. */}
+          {(user.status === "invited" || user.status === "invite_expired") && (
             <div
               style={{
                 display: "flex",

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from 'react-i18next';
 import type { User } from "./types";
-import { getGravatarUrl, copyInvitationUrl } from "./utils";
+import { getGravatarUrl, userManagementAPI } from "./utils";
 import { error, info } from '../../../../../utils/logger';
 
 interface UserCardProps {
@@ -46,10 +46,14 @@ export const UserCard: React.FC<UserCardProps> = ({
   }
 
   const handleCopyInvite = async () => {
-    if (!user.invite_token) return;
-    
+    if (user.status !== "invited" && user.status !== "invite_expired") return;
+
     try {
-      await copyInvitationUrl(user.invite_token);
+      // Fetch the invite URL on demand from the admin-only endpoint instead of
+      // reading it from the bulk user list — the list response no longer
+      // exposes invite tokens.
+      const { inviteUrl } = await userManagementAPI.getInviteLink(user.id);
+      await navigator.clipboard.writeText(inviteUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -454,7 +458,7 @@ export const UserCard: React.FC<UserCardProps> = ({
       {currentUser && (
         <>
           {/* Invited/Expired Users - Show Copy Invite */}
-          {(user.status === "invited" || user.status === "invite_expired") && user.invite_token && (
+          {(user.status === "invited" || user.status === "invite_expired") && (
             <div
               style={{
                 display: "flex",

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
@@ -9,7 +9,6 @@ export interface User {
   auth_methods: string[];
   status?: string;
   picture?: string;
-  invite_token?: string | null;
 }
 
 export interface Passkey {

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
@@ -9,7 +9,8 @@ export interface User {
   auth_methods: string[];
   status?: string;
   picture?: string;
-  invite_token?: string | null;
+  // invite_token is no longer returned by GET /api/auth-extended/users —
+  // admins fetch it on demand via GET /api/auth-extended/users/:userId/invite-link.
 }
 
 export interface Passkey {

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
@@ -70,6 +70,19 @@ export const userManagementAPI = {
     return data.users || [];
   },
 
+  async fetchInviteLink(userId: number): Promise<string> {
+    const res = await fetch(`${API_URL}/api/auth-extended/users/${userId}/invite-link`, {
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to fetch invitation link');
+    }
+    const data = await res.json();
+    if (!data.invite_token) throw new Error('No invitation token returned');
+    return data.invite_token as string;
+  },
+
   async checkSmtpConfig() {
     const res = await fetch(`${API_URL}/api/config`, {
       credentials: 'include',

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
@@ -103,6 +103,25 @@ export const userManagementAPI = {
     return await res.json();
   },
 
+  async getInviteLink(userId: number) {
+    const res = await fetch(
+      `${API_URL}/api/auth-extended/users/${userId}/invite-link`,
+      { credentials: 'include' }
+    );
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to fetch invitation link');
+    }
+
+    return (await res.json()) as {
+      inviteUrl: string;
+      inviteToken: string;
+      expired: boolean;
+      expiresAt: string | null;
+    };
+  },
+
   async resendInvite(userId: number) {
     const res = await fetch(`${API_URL}/api/auth-extended/invite/resend/${userId}`, {
       method: 'POST',


### PR DESCRIPTION
Combines 13 tickets into a single deployment:

- **#538**: [security-audit] POST /api/system/restart only requires requireAuth — any viewer can DoS the backend
- **#506**: [bug-scan] Missing 'error' handler on spawned ffmpeg/ffprobe processes hangs uploads
- **#505**: [bug-scan] `pragma('foreign_keys = OFF/ON')` inside a transaction is a SQLite no-op
- **#537**: [security-audit] CSRF origin check uses startsWith — bypassable with confusable subdomain
- **#502**: [bug-scan] catch handler shadows logger import — TypeError when generateStaticJSONFiles rejects
- **#533**: [security-audit] Setup endpoint /api/setup/initialize has no auth and no completed-setup guard — full account takeover
- **#536**: [security-audit] MFA can be disabled without password verification for OAuth-only users
- **#535**: [security-audit] GET /api/auth-extended/users uses requireAuth instead of requireAdmin — viewer can list all users + invite tokens
- **#503**: [bug-scan] Deleting a credential-login user does not invalidate their existing sessions
- **#504**: [bug-scan] PATCH /:album/rename leaves DB and filesystem inconsistent if directory rename fails
- **#35**: [security-audit] Public EXIF endpoint returns raw GPS coordinates, violating documented privacy guarantee
- **#534**: [security-audit] GET /api/config returns all secrets to any authenticated user (viewer-readable)
- **#32**: [security-audit] GET /api/auth-extended/users leaks invite tokens to any authenticated user

Tracking ticket: #539