### PR TITLE
fix: harden /api/system/restart with CSRF + per-IP rate limit (ticket #634)

### DIFF
--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -8,7 +8,9 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
+import rateLimit from 'express-rate-limit';
 import { requireAdmin } from '../auth/middleware.js';
+import { csrfProtection } from '../security.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,8 +18,24 @@ const __dirname = path.dirname(__filename);
 
 const router = Router();
 
+// Apply CSRF protection to all state-changing routes in this router.
+// (csrfProtection no-ops on GET/HEAD/OPTIONS, so it's safe to mount globally.)
+router.use(csrfProtection);
+
+// Strict per-IP rate limit for the restart endpoint. Restarting the process
+// is destructive to every connected user, so even an authenticated admin
+// should not be able to loop it. The global /api limiter is too permissive
+// for this specific action; cap to a handful of attempts per 15 minutes.
+const restartLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 3,
+  message: { success: false, error: 'Too many restart attempts. Please wait before trying again.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 // Restart endpoint - triggers container restart or PM2 restart
-router.post('/restart', requireAdmin, (req, res) => {
+router.post('/restart', restartLimiter, requireAdmin, (req, res) => {
   try {
     // Get user info for logging
     const userId = (req.session as any)?.userId;


### PR DESCRIPTION
## Summary

Closes ticket #634 — `[security-audit] Authenticated viewer can restart the server (DoS) via /api/system/restart`.

The endpoint already required `requireAdmin` (the audit finding's evidence was stale on this point), but had no CSRF check and no endpoint-specific rate limit. Two changes in `backend/src/routes/system.ts`:

- Mount `csrfProtection` on the system router (same pattern used in `routes/config.ts` and `routes/branding.ts` — middleware no-ops on safe methods, enforces auth + same-origin on POST/PUT/DELETE).
- Add a strict per-IP `express-rate-limit` of 3 requests per 15 minutes specifically for `/restart`. The global `/api` limiter is too permissive for an action that takes the process down for every other user; a stolen admin session or a buggy client can no longer loop the endpoint into a denial-of-service.

`requireAdmin` was already in place, so no auth-level changes were needed.

## Test plan

- [ ] CI: backend `tsc` build succeeds.
- [ ] Manual: as an admin, hit `POST /api/system/restart` four times in quick succession — fourth call returns 429.
- [ ] Manual: a cross-origin POST (no/invalid Origin header) returns 403 from `csrfProtection`.
- [ ] Manual: same-origin admin restart still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)