### PR TITLE
fix: prevent double onError on optimization timeout (ticket #627)

### DIFF
--- a/backend/src/routes/optimization-stream.ts
+++ b/backend/src/routes/optimization-stream.ts
@@ -109,10 +109,19 @@ async function processQueue() {
 
     activeJobs.add(childProcess);
 
+    // Track whether this job has already settled (completed, errored, or
+    // timed out) so timeout/close/error each only run side-effects once.
+    // Without this, a timeout SIGTERM later triggers `close` with a
+    // non-zero code, double-firing onError and double-decrementing the
+    // active-job slot. See ticket #627.
+    let settled = false;
+
     // Add timeout to prevent hung processes (5 minutes)
     const timeout = setTimeout(() => {
       error(`[OptimizationStream] Job ${job.jobId} timed out after 5 minutes, killing process`);
       childProcess.kill('SIGTERM');
+      if (settled) return;
+      settled = true;
       activeJobs.delete(childProcess);
       job.onError('Optimization timed out');
       processQueue();
@@ -141,6 +150,8 @@ async function processQueue() {
     // Handle completion
     childProcess.on('close', (code) => {
       clearTimeout(timeout);
+      if (settled) return;
+      settled = true;
       activeJobs.delete(childProcess);
 
       if (code === 0) {
@@ -158,6 +169,8 @@ async function processQueue() {
     // Handle errors
     childProcess.on('error', (err) => {
       clearTimeout(timeout);
+      if (settled) return;
+      settled = true;
       activeJobs.delete(childProcess);
       error(`[OptimizationStream] Error in job ${job.jobId}:`, err);
       job.onError(err.message);


### PR DESCRIPTION
## Summary

Fixes a race in `backend/src/routes/optimization-stream.ts` where a 5-minute job
timeout fires `onError` twice and double-decrements the active-job slot.

The timeout handler `kill('SIGTERM')`s the child, removes it from `activeJobs`,
calls `job.onError('Optimization timed out')`, and re-runs `processQueue()`. The
SIGTERM then causes the child's `close` event to fire with a non-zero exit code,
which deletes from `activeJobs` again (no-op), calls
`job.onError('Optimization failed with code …')` a second time, and re-runs
`processQueue()` — briefly oversubscribing the worker pool and broadcasting two
error states for the same file.

The fix is to track a per-job `settled` boolean inside the spawn scope. Whichever
of `timeout` / `close` / `error` fires first flips it and runs the side effects;
subsequent firings still `clearTimeout` defensively (in `close`/`error`) but
short-circuit before deleting from `activeJobs`, calling `onError`, or
re-entering `processQueue`.

## Test plan

- [ ] CI typecheck/build passes on the PR
- [ ] Manual: trigger an optimization that hangs past 5min — verify only one error
  broadcast per file and `activeJobs.size` decrements once