### PR TITLE
fix: gate GET /share-links/album/:album behind requireManager (ticket #628)

### DIFF
--- a/backend/src/routes/share-links.ts
+++ b/backend/src/routes/share-links.ts
@@ -5,7 +5,7 @@
 
 import { Router, Request, Response } from "express";
 import { csrfProtection } from "../security.js";
-import { requireAuth, requireManager } from '../auth/middleware.js';
+import { requireManager } from '../auth/middleware.js';
 import { 
   createShareLink, 
   getShareLinkBySecret, 
@@ -178,10 +178,10 @@ router.get("/validate/:secretKey", async (req: Request, res: Response): Promise<
 });
 
 /**
- * Get all share links for an album (admin only)
+ * Get all share links for an album (manager/admin only)
  * GET /api/share-links/album/:album
  */
-router.get("/album/:album", requireAuth, async (req: Request, res: Response): Promise<void> => {
+router.get("/album/:album", requireManager, async (req: Request, res: Response): Promise<void> => {
   try {
     const { album } = req.params;
     


### PR DESCRIPTION
## Summary
- Closes ticket #628 (HIGH severity logic bug).
- `GET /api/share-links/album/:album` was documented "admin only" and returns the raw `secret_key` for every share link of an album, but it was gated only by `requireAuth`. Any signed-in viewer could enumerate secret keys that grant access to unpublished albums.
- Switched the middleware to `requireManager` to match the DELETE counterpart on the same path and the route's own doc comment.
- Removed the now-unused `requireAuth` import in the same file.

## Why `requireManager` (not `requireAdmin`)
The DELETE handler on the same path uses `requireManager` and the comment was updated to "manager/admin only" to reflect the actual semantics here — managers are the role that legitimately creates/manages share links (the POST `/create` route also uses `requireManager`). Tightening to `requireAdmin` would diverge from the existing share-link role model.

## Frontend impact
None. Grepping the frontend for `share-links/album` returns zero hits — only `/api/share-links/create` is called from the UI (`ShareModal.tsx`, `VideoShareModal.tsx`). Viewers were never expected to hit this endpoint.

## Test plan
- [ ] CI passes (typecheck, lint, any backend tests)
- [ ] Manual: signed-in viewer hitting `GET /api/share-links/album/<album>` now receives `403`
- [ ] Manual: manager/admin still receives the share-link list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)