### PR TITLE
fix(security): sanitize branding.customCSS to prevent stored XSS (#633)

### DIFF
--- a/backend/src/routes/branding.ts
+++ b/backend/src/routes/branding.ts
@@ -261,6 +261,25 @@ router.put("/", requireManager, (req: Request, res: Response) => {
               .json({ error: "Custom CSS is too long (max 50KB)" });
             return;
           }
+          // Reject sequences that could break out of the <style> raw-text
+          // element or smuggle in script content when this string is
+          // server-side interpolated into <style id="custom-css">…</style>
+          // by frontend/server.js. Blocks </style, </script, <!--, <script
+          // and HTML-entity-encoded equivalents (defense-in-depth — entities
+          // are not decoded inside <style>, but the audit asked for them).
+          // Note: we deliberately allow ">" since CSS uses it for child
+          // combinators (e.g. ".a > .b").
+          const dangerousCSS = /<\s*\/|<\s*!|<\s*script|&lt;\s*\/|&lt;\s*!|&lt;\s*script|&#0*60;\s*\/|&#0*60;\s*!|&#0*60;\s*script/i;
+          if (dangerousCSS.test(value)) {
+            warn(
+              "[Branding] Rejected customCSS containing HTML-tag-like sequences",
+            );
+            res.status(400).json({
+              error:
+                "Custom CSS may not contain HTML tags, comments, or closing-tag sequences (e.g. </, <!, <script). Use only CSS rules.",
+            });
+            return;
+          }
         } else if (value.length > 500) {
           res
             .status(400)

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -429,6 +429,28 @@ function escapeHtml(str) {
 }
 
 /**
+ * Strip sequences from user-supplied CSS that could break out of a <style>
+ * raw-text element or smuggle in script content. Matches the same patterns
+ * blocked by the backend validator (see backend/src/routes/branding.ts).
+ *
+ * Defense-in-depth: backend rejects bad input on save, but a stale config.json
+ * may still contain legacy payloads. We never want those reaching the browser.
+ */
+function sanitizeCustomCSS(css) {
+  if (typeof css !== "string" || !css) return "";
+  // Block any closing tag (</style, </script, etc.), HTML comments (<!--),
+  // and script-tag openers (<script). Also catch HTML-entity-encoded variants
+  // even though entities are not decoded inside <style> raw text — belt &
+  // braces.
+  const dangerous = /<\s*\/|<\s*!|<\s*script|&lt;\s*\/|&lt;\s*!|&lt;\s*script|&#0*60;\s*\/|&#0*60;\s*!|&#0*60;\s*script/gi;
+  if (dangerous.test(css)) {
+    warn("[Frontend] customCSS contained disallowed sequences; stripping before injection");
+    return css.replace(dangerous, "");
+  }
+  return css;
+}
+
+/**
  * Replace runtime placeholders with current config values
  */
 function replaceRuntimePlaceholders(html, apiUrl) {
@@ -722,7 +744,7 @@ app.get(/^\/.*/, async (req, res) => {
           };
 
           // Inject custom CSS if present
-          const customCSS = configFile.branding?.customCSS || "";
+          const customCSS = sanitizeCustomCSS(configFile.branding?.customCSS || "");
           let htmlWithCustomCSS = htmlWithPlaceholders;
           if (customCSS) {
             htmlWithCustomCSS = htmlWithPlaceholders.replace(
@@ -893,7 +915,7 @@ app.get(/^\/.*/, async (req, res) => {
           };
 
           // Inject custom CSS if present
-          const customCSS = configFile.branding?.customCSS || "";
+          const customCSS = sanitizeCustomCSS(configFile.branding?.customCSS || "");
           let htmlWithCustomCSS = htmlWithPlaceholders;
           if (customCSS) {
             htmlWithCustomCSS = htmlWithPlaceholders.replace(
@@ -1086,7 +1108,7 @@ app.get(/^\/.*/, async (req, res) => {
           };
 
           // Inject custom CSS if present
-          const customCSS = configFile.branding?.customCSS || "";
+          const customCSS = sanitizeCustomCSS(configFile.branding?.customCSS || "");
           let htmlWithCustomCSS = htmlWithPlaceholders;
           if (customCSS) {
             htmlWithCustomCSS = htmlWithPlaceholders.replace(
@@ -1206,7 +1228,7 @@ app.get(/^\/.*/, async (req, res) => {
     };
 
     // Inject custom CSS if present
-    const customCSS = configFile.branding?.customCSS || "";
+    const customCSS = sanitizeCustomCSS(configFile.branding?.customCSS || "");
     if (customCSS) {
       modifiedHtml = modifiedHtml.replace(
         '</head>',

--- a/scripts/generate-homepage-html.js
+++ b/scripts/generate-homepage-html.js
@@ -39,6 +39,21 @@ function log(message) {
   console.log(`${colors.blue}[Homepage SSR]${colors.reset} ${message}`);
 }
 
+/**
+ * Strip sequences from user-supplied CSS that could break out of a <style>
+ * raw-text element or smuggle in script content. Mirrors the same logic in
+ * frontend/server.js and backend/src/routes/branding.ts.
+ */
+function sanitizeCustomCSS(css) {
+  if (typeof css !== 'string' || !css) return '';
+  const dangerous = /<\s*\/|<\s*!|<\s*script|&lt;\s*\/|&lt;\s*!|&lt;\s*script|&#0*60;\s*\/|&#0*60;\s*!|&#0*60;\s*script/gi;
+  if (dangerous.test(css)) {
+    log(`${colors.yellow}WARNING: customCSS contained disallowed sequences; stripping before injection${colors.reset}`);
+    return css.replace(dangerous, '');
+  }
+  return css;
+}
+
 function success(message) {
   console.log(`${colors.green}✓${colors.reset} ${message}`);
 }
@@ -283,7 +298,7 @@ async function generateHomepageHtml() {
     };
 
     // Inject custom CSS if present
-    const customCSS = config.branding?.customCSS || "";
+    const customCSS = sanitizeCustomCSS(config.branding?.customCSS || "");
     if (customCSS) {
       html = html.replace(
         '</head>',


### PR DESCRIPTION
## Summary

Closes ticket #633 (Argus security audit, HIGH severity).

The frontend SSR layer was interpolating `branding.customCSS` directly into a `<style id="custom-css">…</style>` block on every served page, with no escaping or `</style>` filter. The backend `PUT /api/branding` endpoint accepted `customCSS` from any **manager** (a non-admin role) and validated only the 50KB length cap. A manager could ship something like `</style><script>fetch("/api/config")…</script>` and execute arbitrary JS in every visitor's browser, including admins — a clean stepping-stone to chained config/secret exfil.

This PR closes the breakout in two layers:

- **Backend** (`backend/src/routes/branding.ts`) — `PUT /api/branding` now rejects any `customCSS` containing `</`, `<!`, `<script`, or HTML-entity-encoded equivalents, returning `400` with a clear error. This is the authoritative gate.
- **Frontend defense-in-depth** (`frontend/server.js`, `scripts/generate-homepage-html.js`) — every customCSS injection site now runs the value through a `sanitizeCustomCSS()` helper that strips the same sequences. This protects against any pre-existing bad data already on disk in `config.json`.

`>` is intentionally still allowed because CSS uses it for child combinators (`.parent > .child`). The only sequences that can close a `<style>` raw-text element start with `<`, so blocking those is sufficient.

## Test plan

- [ ] CI build & typecheck pass (`backend` TS compiles with the new validator)
- [ ] Manually attempt `PUT /api/branding` with `{"customCSS": "</style><script>alert(1)</script>"}` → expect `400 Bad Request`
- [ ] Manually attempt `PUT /api/branding` with `{"customCSS": ".parent > .child { color: red; }"}` → expect `200 OK` (child combinators still work)
- [ ] Verify a page served by `frontend/server.js` with a clean `customCSS` still renders the `<style id="custom-css">` block correctly
- [ ] Confirm a config.json with a pre-existing malicious `customCSS` no longer emits `</style>...` into served HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)