### PR TITLE
fix(auth): close WebAuthn passkey-counter race (ticket #625)

### DIFF
--- a/backend/src/database-users.ts
+++ b/backend/src/database-users.ts
@@ -316,84 +316,142 @@ export function verifyBackupCode(user: User, code: string): boolean {
 
 /**
  * Add passkey to user
+ *
+ * Wrapped in a SQLite transaction so the read-modify-write of the
+ * passkeys JSON blob is atomic. Without the transaction, two concurrent
+ * adds could each read the same row, append their own passkey, and the
+ * later write would clobber the earlier one (silent passkey loss).
  */
 export function addPasskey(userId: number, passkey: Omit<Passkey, 'created_at'>): boolean {
   const db = getDatabase();
-  const user = getUserById(userId);
-  if (!user) return false;
-  
-  const passkeys = user.passkeys || [];
-  passkeys.push({
-    ...passkey,
-    created_at: new Date().toISOString(),
-  });
-  
-  // Add 'passkey' to auth methods if not already there
-  const authMethods = [...user.auth_methods];
-  if (!authMethods.includes('passkey')) {
-    authMethods.push('passkey');
-  }
-  
+
   const stmt = db.prepare(`
-    UPDATE users 
+    UPDATE users
     SET passkeys = ?, auth_methods = ?, updated_at = CURRENT_TIMESTAMP
     WHERE id = ?
   `);
-  
-  const result = stmt.run(JSON.stringify(passkeys), JSON.stringify(authMethods), userId);
-  return result.changes > 0;
+
+  const tx = db.transaction((uid: number, pk: Omit<Passkey, 'created_at'>): boolean => {
+    const user = getUserById(uid);
+    if (!user) return false;
+
+    const passkeys = user.passkeys || [];
+    passkeys.push({
+      ...pk,
+      created_at: new Date().toISOString(),
+    });
+
+    // Add 'passkey' to auth methods if not already there
+    const authMethods = [...user.auth_methods];
+    if (!authMethods.includes('passkey')) {
+      authMethods.push('passkey');
+    }
+
+    const result = stmt.run(JSON.stringify(passkeys), JSON.stringify(authMethods), uid);
+    return result.changes > 0;
+  });
+
+  return tx(userId, passkey);
 }
 
 /**
  * Remove passkey from user
+ *
+ * Wrapped in a SQLite transaction so a concurrent add or remove on the
+ * same user cannot be lost between this read and write.
  */
 export function removePasskey(userId: number, passkeyId: string): boolean {
   const db = getDatabase();
-  const user = getUserById(userId);
-  if (!user || !user.passkeys) return false;
-  
-  const passkeys = user.passkeys.filter(pk => pk.id !== passkeyId);
-  
-  // If no more passkeys, remove 'passkey' from auth methods
-  const authMethods = passkeys.length === 0
-    ? user.auth_methods.filter(m => m !== 'passkey')
-    : user.auth_methods;
-  
+
   const stmt = db.prepare(`
-    UPDATE users 
+    UPDATE users
     SET passkeys = ?, auth_methods = ?, updated_at = CURRENT_TIMESTAMP
     WHERE id = ?
   `);
-  
-  const result = stmt.run(
-    passkeys.length > 0 ? JSON.stringify(passkeys) : null,
-    JSON.stringify(authMethods),
-    userId
-  );
-  
-  return result.changes > 0;
+
+  const tx = db.transaction((uid: number, pkId: string): boolean => {
+    const user = getUserById(uid);
+    if (!user || !user.passkeys) return false;
+
+    const passkeys = user.passkeys.filter(pk => pk.id !== pkId);
+
+    // If no more passkeys, remove 'passkey' from auth methods
+    const authMethods = passkeys.length === 0
+      ? user.auth_methods.filter(m => m !== 'passkey')
+      : user.auth_methods;
+
+    const result = stmt.run(
+      passkeys.length > 0 ? JSON.stringify(passkeys) : null,
+      JSON.stringify(authMethods),
+      uid
+    );
+
+    return result.changes > 0;
+  });
+
+  return tx(userId, passkeyId);
 }
 
 /**
- * Update passkey counter (for replay attack prevention)
+ * Update passkey counter (for replay attack prevention).
+ *
+ * The counter MUST advance monotonically — that's how WebAuthn detects
+ * cloned authenticators / replayed assertions. Pass the counter that was
+ * verified against (`expectedCurrentCounter`); the update is performed
+ * inside a SQLite transaction with a compare-and-swap check so two
+ * concurrent assertions cannot both succeed against the same stored
+ * counter.
+ *
+ * Returns `false` if:
+ *   - the user or passkey no longer exists
+ *   - the stored counter has already moved past `expectedCurrentCounter`
+ *     (another assertion won the race — caller MUST treat this as a
+ *     replay and reject the authentication)
+ *   - `newCounter` does not strictly advance the stored counter
  */
-export function updatePasskeyCounter(userId: number, passkeyId: string, newCounter: number): boolean {
+export function updatePasskeyCounter(
+  userId: number,
+  passkeyId: string,
+  expectedCurrentCounter: number,
+  newCounter: number
+): boolean {
   const db = getDatabase();
-  const user = getUserById(userId);
-  if (!user || !user.passkeys) return false;
-  
-  const passkeys = user.passkeys.map(pk => 
-    pk.id === passkeyId ? { ...pk, counter: newCounter } : pk
-  );
-  
+
   const stmt = db.prepare(`
-    UPDATE users 
+    UPDATE users
     SET passkeys = ?, updated_at = CURRENT_TIMESTAMP
     WHERE id = ?
   `);
-  
-  const result = stmt.run(JSON.stringify(passkeys), userId);
-  return result.changes > 0;
+
+  const tx = db.transaction(
+    (uid: number, pkId: string, expected: number, next: number): boolean => {
+      const user = getUserById(uid);
+      if (!user || !user.passkeys) return false;
+
+      const current = user.passkeys.find(pk => pk.id === pkId);
+      if (!current) return false;
+
+      // Compare-and-swap: bail if the stored counter has moved since the
+      // caller verified the assertion. A concurrent (or replayed) assertion
+      // already advanced it — accepting this write would silently re-open
+      // the replay window the WebAuthn counter is meant to close.
+      if (current.counter !== expected) return false;
+
+      // Counters must strictly advance. A WebAuthn authenticator is allowed
+      // to keep counter at 0 (no signing counter), in which case the strict
+      // check is skipped — but anything > 0 must increase.
+      if (expected !== 0 && next <= expected) return false;
+
+      const passkeys = user.passkeys.map(pk =>
+        pk.id === pkId ? { ...pk, counter: next } : pk
+      );
+
+      const result = stmt.run(JSON.stringify(passkeys), uid);
+      return result.changes > 0;
+    }
+  );
+
+  return tx(userId, passkeyId, expectedCurrentCounter, newCounter);
 }
 
 /**

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -140,12 +140,23 @@ async function verifyReauth(
         return { ok: false, status: 401, reason: 'Passkey verification failed' };
       }
       // Consume the challenge and bump the credential counter so the assertion
-      // cannot be replayed.
-      updatePasskeyCounter(
+      // cannot be replayed. The counter update is a compare-and-swap against
+      // `result.passkey.counter`; if a concurrent assertion already advanced
+      // the counter we MUST reject this one as a replay rather than accepting
+      // the auth and silently failing to advance the counter.
+      const counterAdvanced = updatePasskeyCounter(
         user.id,
         result.passkey.id,
+        result.passkey.counter,
         verification.authenticationInfo.newCounter
       );
+      if (!counterAdvanced) {
+        warn('[AuthExtended] Re-auth passkey counter CAS failed — possible replay', {
+          userId: user.id,
+          passkeyId: result.passkey.id,
+        });
+        return { ok: false, status: 401, reason: 'Passkey verification failed' };
+      }
       challenges.delete(`passkey-auth-${passkeySessionId}`);
       return { ok: true };
     } catch (err) {
@@ -1375,8 +1386,24 @@ router.post('/passkey/auth-verify', async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Passkey verification failed' });
     }
 
-    // Update counter
-    updatePasskeyCounter(user.id, passkey.id, verification.authenticationInfo.newCounter);
+    // Compare-and-swap on the credential counter. If another assertion won
+    // the race and already advanced the stored counter past what we verified
+    // against, treat this as a replay and reject — accepting it would mean
+    // two assertions succeeded against the same stored counter, which is
+    // exactly what the WebAuthn signature counter is designed to prevent.
+    const counterAdvanced = updatePasskeyCounter(
+      user.id,
+      passkey.id,
+      passkey.counter,
+      verification.authenticationInfo.newCounter
+    );
+    if (!counterAdvanced) {
+      warn('[Passkey Login] Counter CAS failed — possible replay', {
+        userId: user.id,
+        passkeyId: passkey.id,
+      });
+      return res.status(401).json({ error: 'Passkey verification failed' });
+    }
     challenges.delete(`passkey-auth-${sessionId}`);
 
     // Create session


### PR DESCRIPTION
## Summary

Closes the WebAuthn replay window in `updatePasskeyCounter` and the related TOCTOU bugs in `addPasskey` / `removePasskey` (ticket #625).

The three functions in `backend/src/database-users.ts` did a read-modify-write across separate statements: `getUserById` → mutate JSON in memory → `UPDATE users SET passkeys = ?`. Because the passkey verify path `await`s `verifyPasskeyAuthentication` between reading the user and calling `updatePasskeyCounter`, two concurrent assertions could both verify against the same stored counter and both write `N+1`. That defeats the WebAuthn signature counter — the whole point of which is to detect cloned authenticators / replayed assertions.

Fix:

- All three functions are wrapped in `db.transaction(...)`. better-sqlite3 is sync and single-connection, so the transaction body runs as one uninterruptible synchronous block — no `await` can sneak in between read and write.
- `updatePasskeyCounter` gains an `expectedCurrentCounter` arg and now does a compare-and-swap: if the stored counter has already moved past what the caller verified against, the update returns `false` (replay/concurrent-winner detected). It also defensively rejects writes that don't strictly advance.
- Both call sites in `backend/src/routes/auth-extended.ts` (re-auth and passkey login) pass the counter they verified against and treat a `false` return as authentication failure with a `warn` log.

No API surface changes outside the internal `updatePasskeyCounter` signature; both callers are in this repo and updated.

## Test plan

- [ ] CI passes on the PR (TypeScript build + tests)
- [ ] Manual: register a passkey, log in with it, confirm counter advances and login succeeds
- [ ] Manual: replay a captured passkey assertion — second use should fail with 401
- [ ] Manual: re-auth flow (`verifyReauth`) still accepts a fresh passkey assertion
- [ ] Manual: add and remove passkeys still work end-to-end