### PR TITLE
feat: show photo position counter in lightbox modal (ticket #620)

### DIFF
--- a/frontend/src/components/ContentModal/ContentModal.tsx
+++ b/frontend/src/components/ContentModal/ContentModal.tsx
@@ -37,8 +37,8 @@ interface ContentModalProps {
 const ContentModal: React.FC<ContentModalProps> = ({
   selectedPhoto,
   album,
-  currentIndex: _currentIndex, // Unused but kept for future UI features
-  totalPhotos: _totalPhotos, // Unused but kept for future UI features
+  currentIndex,
+  totalPhotos,
   onNavigatePrev,
   onNavigateNext,
   onClose,
@@ -691,6 +691,8 @@ const ContentModal: React.FC<ContentModalProps> = ({
               showHint={showNavigationHint}
               onPrevious={handleNavigatePrev}
               onNext={handleNavigateNext}
+              currentIndex={currentIndex}
+              totalPhotos={totalPhotos}
               style={{}}
             />
 

--- a/frontend/src/components/ContentModal/ModalNavigation.tsx
+++ b/frontend/src/components/ContentModal/ModalNavigation.tsx
@@ -11,6 +11,8 @@ interface ModalNavigationProps {
   showHint: boolean;
   onPrevious: () => void;
   onNext: () => void;
+  currentIndex?: number;
+  totalPhotos?: number;
   style?: React.CSSProperties;
 }
 
@@ -18,10 +20,18 @@ const ModalNavigation: React.FC<ModalNavigationProps> = ({
   showHint,
   onPrevious,
   onNext,
+  currentIndex,
+  totalPhotos,
   style,
 }) => {
   const { t } = useTranslation();
-  
+
+  const showCounter =
+    typeof currentIndex === 'number' &&
+    typeof totalPhotos === 'number' &&
+    totalPhotos > 1;
+  const currentPosition = showCounter ? (currentIndex as number) + 1 : 0;
+
   return (
     <>
       {showHint && (
@@ -29,12 +39,27 @@ const ModalNavigation: React.FC<ModalNavigationProps> = ({
           {t('photoModal.navigationHint')}
         </div>
       )}
-      
+
       <div className="modal-navigation" style={style}>
         <button onClick={onPrevious}>
           <ChevronLeftIcon width="32" height="32" />
         </button>
-        
+
+        {showCounter && (
+          <div
+            className="modal-navigation-counter"
+            aria-label={t('photoModal.positionAriaLabel', {
+              current: currentPosition,
+              total: totalPhotos,
+            })}
+          >
+            {t('photoModal.position', {
+              current: currentPosition,
+              total: totalPhotos,
+            })}
+          </div>
+        )}
+
         <button onClick={onNext}>
           <ChevronRightIcon width="32" height="32" />
         </button>

--- a/frontend/src/components/ContentModal/PhotoModal.css
+++ b/frontend/src/components/ContentModal/PhotoModal.css
@@ -287,6 +287,23 @@
   height: 20px;
 }
 
+/* Position counter shown between prev/next buttons */
+.modal-navigation-counter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 56px;
+  padding: 0 0.5rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.875rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8);
+  user-select: none;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
 /* Image Title */
 .modal-image-title {
   position: absolute;

--- a/frontend/src/i18n/locales/bg.json
+++ b/frontend/src/i18n/locales/bg.json
@@ -53,7 +53,9 @@
     "headBackHome": "Върни се у дома"
   },
   "photoModal": {
-    "navigationHint": "← натиснете стрелките за навигация →"
+    "navigationHint": "← натиснете стрелките за навигация →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Галерия",

--- a/frontend/src/i18n/locales/ca.json
+++ b/frontend/src/i18n/locales/ca.json
@@ -53,7 +53,9 @@
     "headBackHome": "Torna a casa"
   },
   "photoModal": {
-    "navigationHint": "← prem les tecles de fletxa per navegar →"
+    "navigationHint": "← prem les tecles de fletxa per navegar →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galeria",

--- a/frontend/src/i18n/locales/cs.json
+++ b/frontend/src/i18n/locales/cs.json
@@ -53,7 +53,9 @@
     "headBackHome": "Vrátit se domů"
   },
   "photoModal": {
-    "navigationHint": "← stiskněte šipky pro navigaci →"
+    "navigationHint": "← stiskněte šipky pro navigaci →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galerie",

--- a/frontend/src/i18n/locales/da.json
+++ b/frontend/src/i18n/locales/da.json
@@ -53,7 +53,9 @@
     "headBackHome": "Gå tilbage til start"
   },
   "photoModal": {
-    "navigationHint": "← tryk på piletasterne for at navigere →"
+    "navigationHint": "← tryk på piletasterne for at navigere →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galleri",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -53,7 +53,9 @@
     "headBackHome": "Zurück zur Startseite"
   },
   "photoModal": {
-    "navigationHint": "← Pfeiltasten drücken, um zu navigieren →"
+    "navigationHint": "← Pfeiltasten drücken, um zu navigieren →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Alben",

--- a/frontend/src/i18n/locales/el.json
+++ b/frontend/src/i18n/locales/el.json
@@ -53,7 +53,9 @@
     "headBackHome": "Επιστροφή στην Αρχική Σελίδα"
   },
   "photoModal": {
-    "navigationHint": "← πατήστε τα πλήκτρα βέλους για πλοήγηση →"
+    "navigationHint": "← πατήστε τα πλήκτρα βέλους για πλοήγηση →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Γκαλερί",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -53,7 +53,9 @@
     "headBackHome": "Head Back Home"
   },
   "photoModal": {
-    "navigationHint": "← press arrow keys to navigate →"
+    "navigationHint": "← press arrow keys to navigate →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galleria",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -53,7 +53,9 @@
     "headBackHome": "Volver al Inicio"
   },
   "photoModal": {
-    "navigationHint": "← presiona las teclas de flecha para navegar →"
+    "navigationHint": "← presiona las teclas de flecha para navegar →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Álbumes",

--- a/frontend/src/i18n/locales/eu.json
+++ b/frontend/src/i18n/locales/eu.json
@@ -53,7 +53,9 @@
     "headBackHome": "Itzuli Etxera"
   },
   "photoModal": {
-    "navigationHint": "← gezi teklekin nabigatu →"
+    "navigationHint": "← gezi teklekin nabigatu →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galeria",

--- a/frontend/src/i18n/locales/fi.json
+++ b/frontend/src/i18n/locales/fi.json
@@ -53,7 +53,9 @@
     "headBackHome": "Palaa kotiin"
   },
   "photoModal": {
-    "navigationHint": "← käytä nuolinäppäimiä navigointiin →"
+    "navigationHint": "← käytä nuolinäppäimiä navigointiin →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galleria",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -53,7 +53,9 @@
     "headBackHome": "Retour à l'Accueil"
   },
   "photoModal": {
-    "navigationHint": "← appuyez sur les flèches du clavier pour naviguer →"
+    "navigationHint": "← appuyez sur les flèches du clavier pour naviguer →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Albums",

--- a/frontend/src/i18n/locales/hr.json
+++ b/frontend/src/i18n/locales/hr.json
@@ -53,7 +53,9 @@
     "headBackHome": "Vrati se kući"
   },
   "photoModal": {
-    "navigationHint": "← pritisni tipke sa strelicama za navigaciju →"
+    "navigationHint": "← pritisni tipke sa strelicama za navigaciju →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galerija",

--- a/frontend/src/i18n/locales/hu.json
+++ b/frontend/src/i18n/locales/hu.json
@@ -53,7 +53,9 @@
     "headBackHome": "Vissza a kezdőlapra"
   },
   "photoModal": {
-    "navigationHint": "← nyomd meg a nyílbillentyűket a navigáláshoz →"
+    "navigationHint": "← nyomd meg a nyílbillentyűket a navigáláshoz →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galéria",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -53,7 +53,9 @@
     "headBackHome": "Kembali ke Beranda"
   },
   "photoModal": {
-    "navigationHint": "← tekan tombol panah untuk menavigasi →"
+    "navigationHint": "← tekan tombol panah untuk menavigasi →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Album",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -53,7 +53,9 @@
     "headBackHome": "Torna a casa"
   },
   "photoModal": {
-    "navigationHint": "← premi i tasti freccia per navigare →"
+    "navigationHint": "← premi i tasti freccia per navigare →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Album",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -53,7 +53,9 @@
     "headBackHome": "ホームに戻る"
   },
   "photoModal": {
-    "navigationHint": "← 矢印キーを押して移動 →"
+    "navigationHint": "← 矢印キーを押して移動 →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "アルバム",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -53,7 +53,9 @@
     "headBackHome": "홈으로 돌아가기"
   },
   "photoModal": {
-    "navigationHint": "← 화살표 키를 눌러 탐색하세요 →"
+    "navigationHint": "← 화살표 키를 눌러 탐색하세요 →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "앨범",

--- a/frontend/src/i18n/locales/la.json
+++ b/frontend/src/i18n/locales/la.json
@@ -53,7 +53,9 @@
     "headBackHome": "Redi Domi"
   },
   "photoModal": {
-    "navigationHint": "← sagittas preme ad navigandum →"
+    "navigationHint": "← sagittas preme ad navigandum →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galleria",

--- a/frontend/src/i18n/locales/lt.json
+++ b/frontend/src/i18n/locales/lt.json
@@ -53,7 +53,9 @@
     "headBackHome": "Grįžti namo"
   },
   "photoModal": {
-    "navigationHint": "← naudokite rodyklių klavišus navigacijai →"
+    "navigationHint": "← naudokite rodyklių klavišus navigacijai →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galerija",

--- a/frontend/src/i18n/locales/ms.json
+++ b/frontend/src/i18n/locales/ms.json
@@ -53,7 +53,9 @@
     "headBackHome": "Kembali ke Halaman Utama"
   },
   "photoModal": {
-    "navigationHint": "← tekan kekunci anak panah untuk navigasi →"
+    "navigationHint": "← tekan kekunci anak panah untuk navigasi →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galeri",

--- a/frontend/src/i18n/locales/my.json
+++ b/frontend/src/i18n/locales/my.json
@@ -53,7 +53,9 @@
     "headBackHome": "နေအိမ်သို့ ပြန်သွားပါ"
   },
   "photoModal": {
-    "navigationHint": "← လမ်းညွှန်ချက်များကို သုံး၍ သွားပါ →"
+    "navigationHint": "← လမ်းညွှန်ချက်များကို သုံး၍ သွားပါ →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - ဂယ်လရီယာ",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -53,7 +53,9 @@
     "headBackHome": "Ga terug naar huis"
   },
   "photoModal": {
-    "navigationHint": "← druk op de pijltoetsen om te navigeren →"
+    "navigationHint": "← druk op de pijltoetsen om te navigeren →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Albums",

--- a/frontend/src/i18n/locales/no.json
+++ b/frontend/src/i18n/locales/no.json
@@ -53,7 +53,9 @@
     "headBackHome": "Gå tilbake hjem"
   },
   "photoModal": {
-    "navigationHint": "← trykk piltastene for å navigere →"
+    "navigationHint": "← trykk piltastene for å navigere →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Album",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -53,7 +53,9 @@
     "headBackHome": "Wróć do domu"
   },
   "photoModal": {
-    "navigationHint": "← naciśnij klawisze strzałek, aby nawigować →"
+    "navigationHint": "← naciśnij klawisze strzałek, aby nawigować →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Albumy",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -53,7 +53,9 @@
     "headBackHome": "Voltar para Casa"
   },
   "photoModal": {
-    "navigationHint": "← pressione as teclas de seta para navegar →"
+    "navigationHint": "← pressione as teclas de seta para navegar →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Álbuns",

--- a/frontend/src/i18n/locales/ro.json
+++ b/frontend/src/i18n/locales/ro.json
@@ -53,7 +53,9 @@
     "headBackHome": "Întoarce-te acasă"
   },
   "photoModal": {
-    "navigationHint": "← apasă tastele săgeată pentru a naviga →"
+    "navigationHint": "← apasă tastele săgeată pentru a naviga →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Albume",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -53,7 +53,9 @@
     "headBackHome": "Вернуться домой"
   },
   "photoModal": {
-    "navigationHint": "← нажмите стрелки для навигации →"
+    "navigationHint": "← нажмите стрелки для навигации →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Альбомы",

--- a/frontend/src/i18n/locales/sk.json
+++ b/frontend/src/i18n/locales/sk.json
@@ -53,7 +53,9 @@
     "headBackHome": "Vrátiť sa domov"
   },
   "photoModal": {
-    "navigationHint": "← stlačte šípky na navigáciu →"
+    "navigationHint": "← stlačte šípky na navigáciu →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galéria",

--- a/frontend/src/i18n/locales/sl.json
+++ b/frontend/src/i18n/locales/sl.json
@@ -53,7 +53,9 @@
     "headBackHome": "Pojdi nazaj domov"
   },
   "photoModal": {
-    "navigationHint": "← pritisni puščične tipke za navigacijo →"
+    "navigationHint": "← pritisni puščične tipke za navigacijo →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galerija",

--- a/frontend/src/i18n/locales/sr.json
+++ b/frontend/src/i18n/locales/sr.json
@@ -53,7 +53,9 @@
     "headBackHome": "Vrati se na početnu stranu"
   },
   "photoModal": {
-    "navigationHint": "← pritisni strelice za navigaciju →"
+    "navigationHint": "← pritisni strelice za navigaciju →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Galerija",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -53,7 +53,9 @@
     "headBackHome": "Gå tillbaka hem"
   },
   "photoModal": {
-    "navigationHint": "← tryck på piltangenterna för att navigera →"
+    "navigationHint": "← tryck på piltangenterna för att navigera →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Album",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -53,7 +53,9 @@
     "headBackHome": "กลับไปที่หน้าแรก"
   },
   "photoModal": {
-    "navigationHint": "← กดปุ่มลูกศรเพื่อไปยัง →"
+    "navigationHint": "← กดปุ่มลูกศรเพื่อไปยัง →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - แกลเลอเรีย",

--- a/frontend/src/i18n/locales/tl.json
+++ b/frontend/src/i18n/locales/tl.json
@@ -53,7 +53,9 @@
     "headBackHome": "Bumalik sa Tahanan"
   },
   "photoModal": {
-    "navigationHint": "← pindutin ang mga arrow key upang mag-navigate →"
+    "navigationHint": "← pindutin ang mga arrow key upang mag-navigate →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Mga Album",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -53,7 +53,9 @@
     "headBackHome": "Eve Geri Dön"
   },
   "photoModal": {
-    "navigationHint": "← gezinmek için ok tuşlarına basın →"
+    "navigationHint": "← gezinmek için ok tuşlarına basın →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Albümler",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -53,7 +53,9 @@
     "headBackHome": "Повернутися додому"
   },
   "photoModal": {
-    "navigationHint": "← натисніть клавіші зі стрілками для навігації →"
+    "navigationHint": "← натисніть клавіші зі стрілками для навігації →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "seo": {
     "homepageTitle": "{{siteName}} - Галерея",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -53,7 +53,9 @@
     "headBackHome": "Quay về Trang Chủ"
   },
   "photoModal": {
-    "navigationHint": "← nhấn phím mũi tên để điều hướng →"
+    "navigationHint": "← nhấn phím mũi tên để điều hướng →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "Album",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -53,7 +53,9 @@
     "headBackHome": "返回主页"
   },
   "photoModal": {
-    "navigationHint": "← 按箭头键进行导航 →"
+    "navigationHint": "← 按箭头键进行导航 →",
+    "position": "{{current}} / {{total}}",
+    "positionAriaLabel": "[EN] Photo {{current}} of {{total}}"
   },
   "header": {
     "albums": "相册",


### PR DESCRIPTION
## Summary

- Renders a position counter (`14 / 47`) between the prev/next buttons in the lightbox `ModalNavigation` so viewers know where they are in large albums.
- Wires up the `currentIndex` / `totalPhotos` props in `ContentModal` that were already plumbed through and sitting idle behind a "kept for future UI features" comment.
- Hidden automatically when `totalPhotos <= 1`. Tabular numerals so the digits don't reflow as you click through.
- Adds `photoModal.position` (visible) and `photoModal.positionAriaLabel` (screen reader) translation keys, propagated to all 36 locales via `scripts/sync-translation-keys.js`. Stripped the `[EN]` prefix from the visible numeric format since it's universal; left it on the aria label so the normal auto-translate workflow picks it up.

Closes ticket #620.

## Test plan

- [ ] Open an album with 2+ photos, click any photo, confirm `n / total` appears between the nav arrows.
- [ ] Navigate prev/next — counter updates correctly.
- [ ] Open a single-photo album/page — counter is hidden.
- [ ] Verify it shows on both desktop and mobile (the `.modal-navigation` is in the bottom-right of the modal).
- [ ] Screen reader announces "Photo X of Y" via the aria-label.