### PR TITLE
fix(admin): use shared ConfirmModalConfig in ModalsCollection (ticket #641)

### DIFF
--- a/frontend/src/components/AdminPortal/AlbumsManager/components/ModalsCollection.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/ModalsCollection.tsx
@@ -9,24 +9,12 @@ import { API_URL } from '../../../../config';
 import { createPortal } from 'react-dom';
 import ShareModal from '../../ShareModal';
 import MoveToFolderModal from './MoveToFolderModal';
-import { Photo, Folder } from '../types';
+import { Photo, Folder, ConfirmModalConfig } from '../types';
 import { cacheBustValue } from '../../../../config';
 import { MagicWandIcon } from '../../../icons';
 import { error } from '../../../../utils/logger';
 import VideoThumbnailPicker from './VideoThumbnailPicker';
 
-
-interface ConfirmModalConfig {
-  message: string;
-  onConfirm: () => void;
-  confirmText?: string;
-  isDanger?: boolean;
-  photo?: {
-    thumbnail: string;
-    title?: string;
-    filename: string;
-  };
-}
 
 interface ModalsCollectionProps {
   // Edit Photo Modal


### PR DESCRIPTION
## Summary
- After ticket #639 deployed, `tsc -b` failed in the frontend build with `Property 'title' does not exist on type 'ConfirmModalConfig'` at `ModalsCollection.tsx:994/995`.
- The cause was a stale duplicate: `ModalsCollection.tsx` declared its own local `ConfirmModalConfig` interface that had drifted from the canonical one exported from `../types.ts`. The shared type gained `title?: string` in batch #59 (album-descriptions feature), but the local copy was never updated.
- Fix: delete the local duplicate and import `ConfirmModalConfig` from `../types`. The two shapes are otherwise identical, so this is a no-op at runtime.

## Test plan
- [ ] CI: `tsc -b && vite build` succeeds in the frontend workspace.
- [ ] Manual smoke: open the Admin > Albums view and trigger any flow that opens the generic confirmation modal (delete photo, delete album, etc.) — header text still renders correctly, including any caller that passes an explicit `title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)