### PR TITLE
fix(auth): reject deactivated users on passkey login (ticket #690)

### DIFF
--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1374,6 +1374,13 @@ router.post('/passkey/auth-verify', async (req: Request, res: Response) => {
 
     const { user, passkey } = result;
 
+    // Reject deactivated accounts before doing any crypto work. Mirrors the
+    // is_active gate in the credential /login handler so that disabling a user
+    // also revokes their passkey-based access.
+    if (!user.is_active) {
+      return res.status(401).json({ error: 'Account is disabled' });
+    }
+
     // Verify authentication
     const verification = await verifyPasskeyAuthentication(
       credential,


### PR DESCRIPTION
## Summary

Closes ticket #690 (HIGH severity bug-scan finding).

The `/passkey/auth-verify` handler in `backend/src/routes/auth-extended.ts` was creating a session for any user with a valid passkey, even after an admin had set `is_active = false`. Deactivated users could keep signing in via WebAuthn, defeating the deactivation control.

The credential `/login` handler (line 294) and the NextAuth credentials provider (`backend/src/auth/config.ts` line 109) already gate on `is_active`. This change mirrors that gate immediately after `getPasskeyByCredentialId` resolves the credential to a user, before the verification step — so the check happens regardless of whether the WebAuthn signature would have verified.

Error message and 401 status match the existing credential-login response (`'Account is disabled'`) for consistency.

## Test plan

- [ ] CI passes on the PR
- [ ] Manually verify: deactivate a user with a registered passkey, attempt passkey login, confirm 401 `Account is disabled` and no session created
- [ ] Confirm normal active-user passkey login still succeeds