### PR TITLE
fix: notify only highest reached milestone per tick (ticket #689)

### DIFF
--- a/backend/src/services/milestone-tracker.ts
+++ b/backend/src/services/milestone-tracker.ts
@@ -31,37 +31,48 @@ export async function checkMilestones(): Promise<void> {
       const currentViews = data.views;
       const lastMilestone = data.lastMilestone;
 
-      // Check if any new milestones were reached
-      for (const milestone of MILESTONES) {
+      // Find the highest milestone the album has crossed since lastMilestone.
+      // Iterating in descending order and breaking on the first match ensures
+      // we send a single notification (and perform a single DB write) per tick
+      // even when an album's view count jumps past several thresholds at once.
+      let highestNewMilestone: number | null = null;
+      for (let i = MILESTONES.length - 1; i >= 0; i--) {
+        const milestone = MILESTONES[i];
         if (currentViews >= milestone && lastMilestone < milestone) {
-          // New milestone reached!
-          info(`[MilestoneTracker] 🎉 ${albumName} reached ${milestone} views!`);
-
-          // Send notification to all admins
-          const admins = getAllUsers().filter(u => u.role === 'admin');
-
-          for (const admin of admins) {
-            const title = await translateNotification('notifications.backend.albumViewMilestoneTitle', {
-              albumName,
-              milestone: milestone.toLocaleString()
-            });
-            const body = await translateNotification('notifications.backend.albumViewMilestoneBody', {
-              albumName,
-              milestone: milestone.toLocaleString()
-            });
-
-            await sendNotificationToUser(admin.id, {
-              title,
-              body,
-              tag: `milestone-${albumName}-${milestone}`,
-              requireInteraction: true
-            }, 'albumViewMilestone');
-          }
-
-          // Update milestone in database
-          updateAlbumMilestone(albumName, milestone);
-          milestonesReached++;
+          highestNewMilestone = milestone;
+          break;
         }
+      }
+
+      if (highestNewMilestone !== null) {
+        const milestone = highestNewMilestone;
+        // New milestone reached!
+        info(`[MilestoneTracker] 🎉 ${albumName} reached ${milestone} views!`);
+
+        // Send notification to all admins
+        const admins = getAllUsers().filter(u => u.role === 'admin');
+
+        for (const admin of admins) {
+          const title = await translateNotification('notifications.backend.albumViewMilestoneTitle', {
+            albumName,
+            milestone: milestone.toLocaleString()
+          });
+          const body = await translateNotification('notifications.backend.albumViewMilestoneBody', {
+            albumName,
+            milestone: milestone.toLocaleString()
+          });
+
+          await sendNotificationToUser(admin.id, {
+            title,
+            body,
+            tag: `milestone-${albumName}-${milestone}`,
+            requireInteraction: true
+          }, 'albumViewMilestone');
+        }
+
+        // Update milestone in database
+        updateAlbumMilestone(albumName, milestone);
+        milestonesReached++;
       }
     }
 


### PR DESCRIPTION
## Summary
- Fixes a bug in `backend/src/services/milestone-tracker.ts` where an album crossing several view-count thresholds in a single tick (e.g. 90 → 5500) would trigger a separate admin push notification — and a separate DB write — for each crossed threshold (100, 1000, 5000).
- Inner loop now iterates `MILESTONES` in descending order and breaks on the first match, so each tick produces at most one notification and one DB update per album, for the highest crossed threshold.
- Cross-tick semantics are unchanged: subsequent ticks still skip already-notified milestones because `updateAlbumMilestone` persists the new value.

## Test plan
- [ ] CI build (`tsc`) passes.
- [ ] Manual: simulate an album whose `lastMilestone = 0` and `views = 5500`; verify exactly one notification ("5,000 views") fires and the DB row is updated to 5000.
- [ ] Manual: with `lastMilestone = 5000` and `views = 12000`, verify a single notification for 10000 fires and DB updates to 10000.
- [ ] Manual: with `lastMilestone = 5000` and `views = 5500` (no crossing), verify no notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)