### PR TITLE
fix(setup): handle errors on response/gunzip streams in GeoIP download

### DIFF
--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -69,58 +69,70 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ * Pipe an HTTPS response through gunzip into a file using stream/promises
+ * pipeline(). pipeline() propagates errors from every stream in the chain
+ * (including socket resets on the response and truncated/non-gzip bodies on
+ * gunzip), ensures the destination is closed, and lets us unlink any partial
+ * file on failure. Returns true on success, false on failure.
+ */
+async function pipeResponseToGunzippedFile(
+  response: import('http').IncomingMessage,
+  dbPath: string
+): Promise<boolean> {
+  const gunzip = createGunzip();
+  const fileStream = createWriteStream(dbPath);
+  try {
+    await pipeline(response, gunzip, fileStream);
+    info('[Setup] GeoIP database downloaded successfully');
+    return true;
+  } catch (err) {
+    error('[Setup] Failed to download GeoIP database stream:', err);
+    // Clean up partial file (best-effort; ignore unlink errors so we always
+    // resolve the outer Promise).
+    await fs.promises.unlink(dbPath).catch(() => undefined);
+    return false;
+  }
+}
+
+/**
  * Download GeoIP database for location lookup
  * Uses DB-IP's free database (no registration required)
  */
 async function downloadGeoIPDatabase(dataDir: string): Promise<boolean> {
   try {
     const dbPath = path.join(dataDir, 'GeoLite2-City.mmdb');
-    
+
     // Skip if already exists
     if (fs.existsSync(dbPath)) {
       info('[Setup] GeoIP database already exists, skipping download');
       return true;
     }
-    
+
     info('[Setup] Downloading GeoIP database...');
-    
+
     // Get current year and month for DB-IP URL
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
-    
+
     // DB-IP free database URL (updated monthly)
     const dbipUrl = `https://download.db-ip.com/free/dbip-city-lite-${year}-${month}.mmdb.gz`;
-    
+
     return new Promise((resolve) => {
       https.get(dbipUrl, (response) => {
         if (response.statusCode === 302 || response.statusCode === 301) {
           // Follow redirect
           const redirectUrl = response.headers.location;
+          // Drain the redirect response so the socket can be reused / freed.
+          response.resume();
           if (redirectUrl) {
             info('[Setup] Following redirect to:', redirectUrl);
             https.get(redirectUrl, (redirectResponse) => {
               if (redirectResponse.statusCode === 200) {
-                const gunzip = createGunzip();
-                const fileStream = createWriteStream(dbPath);
-                
-                redirectResponse.pipe(gunzip).pipe(fileStream);
-                
-                fileStream.on('finish', () => {
-                  info('[Setup] GeoIP database downloaded successfully');
-                  resolve(true);
-                });
-                
-                fileStream.on('error', (err) => {
-                  error('[Setup] Failed to write GeoIP database:', err);
-                  // Clean up partial file
-                  if (fs.existsSync(dbPath)) {
-                    fs.unlinkSync(dbPath);
-                  }
-                  resolve(false);
-                });
+                pipeResponseToGunzippedFile(redirectResponse, dbPath).then(resolve);
               } else {
                 warn('[Setup] Failed to download GeoIP database (redirect response):', redirectResponse.statusCode);
+                redirectResponse.resume(); // discard body
                 resolve(false);
               }
             }).on('error', (err) => {
@@ -132,27 +144,11 @@ async function downloadGeoIPDatabase(dataDir: string): Promise<boolean> {
             resolve(false);
           }
         } else if (response.statusCode === 200) {
-          const gunzip = createGunzip();
-          const fileStream = createWriteStream(dbPath);
-          
-          response.pipe(gunzip).pipe(fileStream);
-          
-          fileStream.on('finish', () => {
-            info('[Setup] GeoIP database downloaded successfully');
-            resolve(true);
-          });
-          
-          fileStream.on('error', (err) => {
-            error('[Setup] Failed to write GeoIP database:', err);
-            // Clean up partial file
-            if (fs.existsSync(dbPath)) {
-              fs.unlinkSync(dbPath);
-            }
-            resolve(false);
-          });
+          pipeResponseToGunzippedFile(response, dbPath).then(resolve);
         } else {
           warn('[Setup] Failed to download GeoIP database, status:', response.statusCode);
           warn('[Setup] This is optional - location lookup will show "Location unknown"');
+          response.resume(); // discard body
           resolve(false);
         }
       }).on('error', (err) => {


### PR DESCRIPTION
## Summary

`downloadGeoIPDatabase` in `backend/src/routes/setup.ts` only registered an `error` handler on `fileStream`. If the upstream HTTPS `response` emitted `error` (socket reset mid-download) or `gunzip` emitted `error` (truncated stream / non-gzip body — e.g. db-ip.com returning an HTML error page with status 200), Node would throw an uncaught `'error'` event and the surrounding Promise neither resolved nor rejected — the setup request hung and a partial file was left on disk.

This refactors the two pipe sites (302/301 redirect branch and direct 200 branch) onto `stream/promises.pipeline()`, which was already imported but unused. `pipeline()` propagates errors from every stream in the chain, ensures the destination is closed, and gives one place to unlink the partial file on failure. Also drains (`.resume()`) the redirect-prelude and non-2xx response bodies so their sockets can be released cleanly.

Closes ticket #692.

## Test plan

- [ ] CI passes (typecheck + lint + tests).
- [ ] Manual: run OOBE in a fresh dev env where DB-IP is reachable — confirm `data/GeoLite2-City.mmdb` lands and the existing log lines fire.
- [ ] Manual: simulate failure by pointing `dbipUrl` at an HTML 200 response — confirm `Failed to download GeoIP database stream` logs, no partial file is left, and the setup completes (background promise resolves false instead of hanging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)