### PR TITLE
fix(setup): require one-shot token + admin guard on /api/setup/initialize (ticket #687)

### DIFF
--- a/backend/src/database-users.ts
+++ b/backend/src/database-users.ts
@@ -103,6 +103,33 @@ export function getUserByGoogleId(googleId: string): User | null {
 }
 
 /**
+ * Check whether at least one admin user exists.
+ *
+ * Used by the OOBE setup guard as a belt-and-suspenders check on top of
+ * `getConfigExists()`: if an admin already exists, refuse to re-run the
+ * unauthenticated setup wizard regardless of config.json state. Safe to call
+ * before the users table is created — returns false when the table is missing,
+ * the database is unreachable, or any query error occurs.
+ */
+export function adminUserExists(): boolean {
+  try {
+    const db = getDatabase();
+    // Confirm the users table exists before querying (during OOBE the table
+    // is only created inside /api/setup/initialize).
+    const tableCheck = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+      .get();
+    if (!tableCheck) return false;
+    const row = db
+      .prepare("SELECT 1 FROM users WHERE role = 'admin' LIMIT 1")
+      .get();
+    return Boolean(row);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Create a new user
  */
 export function createUser(data: {

--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -17,15 +17,26 @@ import { createGunzip } from "zlib";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendInstallationEvent } from '../utils/installation-analytics.js';
 import { getConfigExists } from '../config.js';
+import { adminUserExists } from '../database-users.js';
+import {
+  setupTokenExists,
+  verifySetupToken,
+  consumeSetupToken,
+} from '../utils/setup-token.js';
 
 const router = Router();
 
 /**
- * Guard for OOBE-only endpoints. Once config.json exists, the initial setup
- * has already been performed and these endpoints must refuse further calls —
- * otherwise an unauthenticated attacker could overwrite the session secret,
- * authorized emails, OAuth credentials, allowed origins/hosts, and provision
- * a new admin user (full account takeover). See ticket #533.
+ * Guard for OOBE-only endpoints. Once config.json exists OR an admin user is
+ * already provisioned, the initial setup has already been performed and these
+ * endpoints must refuse further calls — otherwise an unauthenticated attacker
+ * could overwrite the session secret, authorized emails, OAuth credentials,
+ * allowed origins/hosts, and provision a new admin user (full account
+ * takeover). See tickets #533 and #687.
+ *
+ * The admin-user check is belt-and-suspenders for the corner case where
+ * data/config.json is missing or got truncated but the user database still
+ * has an admin row.
  *
  * The post-OOBE equivalents live behind authenticated routes (e.g.
  * /api/branding/upload-avatar).
@@ -38,6 +49,17 @@ function refuseIfSetupComplete(
   if (getConfigExists()) {
     warn(
       `[Setup] Refusing ${req.method} ${req.path} — setup has already completed. ` +
+      `Source IP: ${req.ip || req.socket.remoteAddress}`
+    );
+    res.status(403).json({
+      error: "Setup has already completed. This endpoint is disabled.",
+      setupComplete: true,
+    });
+    return;
+  }
+  if (adminUserExists()) {
+    warn(
+      `[Setup] Refusing ${req.method} ${req.path} — an admin user already exists. ` +
       `Source IP: ${req.ip || req.socket.remoteAddress}`
     );
     res.status(403).json({
@@ -272,6 +294,20 @@ router.get("/status", async (req: Request, res: Response): Promise<void> => {
 });
 
 /**
+ * Report whether a one-shot setup token is required for /initialize.
+ *
+ * The OOBE wizard polls this endpoint to know whether to render the token
+ * input field. After /initialize completes the token file is deleted and
+ * this returns { tokenRequired: false }.
+ */
+router.get(
+  "/token-status",
+  (req: Request, res: Response): void => {
+    res.json({ tokenRequired: setupTokenExists() });
+  }
+);
+
+/**
  * Initialize configuration with user-provided values
  */
 router.post(
@@ -289,7 +325,36 @@ router.post(
         googleClientSecret,
         metaDescription,
         language,
+        setupToken,
       } = req.body;
+
+      // Verify the one-shot setup token. The token is generated on backend
+      // startup when no config.json exists and is written to data/setup.token
+      // (also logged to the console). It's consumed on successful init so it
+      // cannot be replayed. See utils/setup-token.ts and ticket #687.
+      if (setupTokenExists()) {
+        if (!verifySetupToken(setupToken)) {
+          warn(
+            `[Setup] Refusing /initialize — missing or invalid setup token. ` +
+            `Source IP: ${req.ip || req.socket.remoteAddress}`
+          );
+          res.status(401).json({
+            error:
+              "Invalid setup token. Copy the token from your server logs " +
+              "or from data/setup.token and paste it into the wizard.",
+          });
+          return;
+        }
+      } else {
+        // No token file means either an extremely old install pre-dating this
+        // change OR the token was already consumed. In the latter case the
+        // refuseIfSetupComplete guard above will already have rejected the
+        // request; reaching this branch means the install pre-dates the token
+        // mechanism, in which case the existing config / admin guards are
+        // still in effect and we accept the request to preserve OOBE for
+        // upgraders mid-flight.
+        info("[Setup] No setup token file present — proceeding with legacy guards.");
+      }
 
       // Validate required fields
       if (!siteName || !authorizedEmail || !authMethod) {
@@ -751,6 +816,9 @@ router.post(
       }).catch(err => {
         warn('[Setup] Failed to send setup_complete event:', err);
       });
+
+      // Consume (delete) the one-shot setup token so it cannot be replayed.
+      consumeSetupToken();
 
       res.json({
         success: true,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -102,6 +102,12 @@ if (getConfigExists()) {
   info(
     "[Server] Setup mode detected - skipping production security validation"
   );
+  // Generate the one-shot setup token that gates /api/setup/initialize.
+  // The operator copies it from logs (or data/setup.token) into the OOBE
+  // wizard. See utils/setup-token.ts and ticket #687.
+  void import("./utils/setup-token.js").then(({ ensureSetupToken }) => {
+    ensureSetupToken();
+  });
 }
 
 // Initialize database lazily (on first use) to avoid ESM/CommonJS issues

--- a/backend/src/utils/setup-token.ts
+++ b/backend/src/utils/setup-token.ts
@@ -1,0 +1,119 @@
+/**
+ * Setup Token
+ *
+ * One-shot token bound to the local installer that gates the unauthenticated
+ * /api/setup/initialize endpoint. Generated on backend startup whenever no
+ * config.json is present and consumed (deleted) once OOBE completes.
+ *
+ * Why this exists: even with refuseIfSetupComplete + admin-user guards, there
+ * is a brief window between server startup and the legitimate operator
+ * submitting the OOBE form during which an attacker who can reach the API
+ * could win the race. Requiring the token — readable only with filesystem
+ * access to the data directory — proves the request originated from the
+ * installer, not the open internet. See ticket #687.
+ */
+
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { DATA_DIR } from "../config.js";
+import { info, warn, error } from "./logger.js";
+
+const TOKEN_FILENAME = "setup.token";
+const TOKEN_BYTES = 32;
+
+function tokenPath(): string {
+  return path.join(DATA_DIR, TOKEN_FILENAME);
+}
+
+/**
+ * Generate (or rehydrate) the one-shot setup token. Idempotent: if the token
+ * file already exists, leaves it in place. Logs the token prominently so the
+ * operator can copy it from console / docker logs / pm2 logs.
+ */
+export function ensureSetupToken(): string | null {
+  try {
+    const filePath = tokenPath();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    if (fs.existsSync(filePath)) {
+      const existing = fs.readFileSync(filePath, "utf8").trim();
+      if (existing) {
+        info("[SetupToken] Existing setup token detected at", filePath);
+        info("[SetupToken] Token (paste into the OOBE wizard):", existing);
+        return existing;
+      }
+    }
+
+    const token = crypto.randomBytes(TOKEN_BYTES).toString("hex");
+    fs.writeFileSync(filePath, token + "\n", { encoding: "utf8", mode: 0o600 });
+    // Some filesystems ignore the mode in writeFileSync — chmod explicitly.
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      /* best-effort */
+    }
+    info("============================================================");
+    info("[SetupToken] One-shot setup token generated.");
+    info("[SetupToken] Path :", filePath);
+    info("[SetupToken] Token:", token);
+    info("[SetupToken] Paste this into the OOBE wizard to finish setup.");
+    info("============================================================");
+    return token;
+  } catch (err) {
+    error("[SetupToken] Failed to generate setup token:", err);
+    return null;
+  }
+}
+
+/**
+ * Returns true when the on-disk setup token file exists.
+ */
+export function setupTokenExists(): boolean {
+  try {
+    return fs.existsSync(tokenPath());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify a candidate token against the on-disk setup token. Uses
+ * timing-safe comparison. Returns false when the file is missing, the
+ * candidate is empty, or the lengths/values disagree.
+ */
+export function verifySetupToken(candidate: unknown): boolean {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  try {
+    const filePath = tokenPath();
+    if (!fs.existsSync(filePath)) return false;
+    const expected = fs.readFileSync(filePath, "utf8").trim();
+    if (!expected) return false;
+    const a = Buffer.from(expected, "utf8");
+    const b = Buffer.from(candidate, "utf8");
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+  } catch (err) {
+    warn("[SetupToken] Verification error:", err);
+    return false;
+  }
+}
+
+/**
+ * Delete the on-disk setup token. Called after a successful /initialize so
+ * the token cannot be replayed.
+ */
+export function consumeSetupToken(): void {
+  try {
+    const filePath = tokenPath();
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+      info("[SetupToken] Consumed and removed:", filePath);
+    }
+  } catch (err) {
+    warn("[SetupToken] Failed to remove token file:", err);
+  }
+}

--- a/frontend/src/components/SetupWizard/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.tsx
@@ -38,6 +38,14 @@ export default function SetupWizard() {
   const [adminPasswordConfirm, setAdminPasswordConfirm] = useState('');
   const [showRestartModal, setShowRestartModal] = useState(false);
   const [animationBoost, setAnimationBoost] = useState(false);
+
+  // One-shot setup token (ticket #687). The backend writes a token to
+  // data/setup.token (and logs it) when no config.json is present; the
+  // operator pastes it here to authorize the unauthenticated /initialize
+  // call. We poll /api/setup/token-status on mount to decide whether to
+  // render the input.
+  const [setupToken, setSetupToken] = useState('');
+  const [tokenRequired, setTokenRequired] = useState(false);
   
   // Trigger animation boost when step changes
   useEffect(() => {
@@ -64,7 +72,21 @@ export default function SetupWizard() {
   // Check setup status on mount
   useEffect(() => {
     checkSetupStatus();
+    checkTokenStatus();
   }, []);
+
+  const checkTokenStatus = async () => {
+    try {
+      const response = await fetch(`${API_URL}/api/setup/token-status`);
+      if (!response.ok) return;
+      const data = await response.json();
+      setTokenRequired(Boolean(data.tokenRequired));
+    } catch (err) {
+      // Non-fatal: if the endpoint is unreachable we hide the field.
+      // The backend will still reject /initialize without a valid token.
+      warn('Setup token status check failed:', err);
+    }
+  };
 
   // Sync currentLanguage with i18n language changes and force re-render
   useEffect(() => {
@@ -176,6 +198,11 @@ export default function SetupWizard() {
       }
     }
 
+    if (tokenRequired && !setupToken.trim()) {
+      setError(t('oobe.setupTokenRequired', 'Setup token is required. Find it in your server logs or in data/setup.token.'));
+      return;
+    }
+
     try {
       setSubmitting(true);
       
@@ -195,6 +222,7 @@ export default function SetupWizard() {
           googleClientSecret: authMethod === 'google' ? googleClientSecret : undefined,
           metaDescription: metaDescription || t('oobe.siteDescriptionPlaceholder', { siteName }),
           language: currentLanguage,
+          setupToken: tokenRequired ? setupToken.trim() : undefined,
         }),
       });
 
@@ -653,6 +681,33 @@ export default function SetupWizard() {
                 {t('oobe.customizeDescription')}
               </p>
 
+              {tokenRequired && (
+                <div className="form-group">
+                  <label htmlFor="setupToken">
+                    {t('oobe.setupTokenLabel', 'Setup token')} *
+                    <span className="field-hint">
+                      {t(
+                        'oobe.setupTokenHint',
+                        'Copy the token from your server logs or from the data/setup.token file on the server.'
+                      )}
+                    </span>
+                  </label>
+                  <input
+                    type="text"
+                    id="setupToken"
+                    value={setupToken}
+                    onChange={(e) => setSetupToken(e.target.value)}
+                    placeholder={t(
+                      'oobe.setupTokenPlaceholder',
+                      'Paste the setup token here'
+                    )}
+                    autoComplete="off"
+                    spellCheck={false}
+                    required
+                  />
+                </div>
+              )}
+
               <div className="form-group">
                 <label htmlFor="avatar">
                   {t('oobe.avatarOptional')}
@@ -697,10 +752,10 @@ export default function SetupWizard() {
                 >
                   {t('oobe.backToAccount')}
                 </button>
-                <button 
+                <button
                   type="submit"
                   className="button button-primary"
-                  disabled={submitting}
+                  disabled={submitting || (tokenRequired && !setupToken.trim())}
                 >
                   {submitting ? t('oobe.settingUp') : t('oobe.completeSetup')}
                 </button>


### PR DESCRIPTION
## Summary
- Building on #533, this hardens the unauthenticated OOBE flow against takeover even when `config.json` is missing/truncated.
- `refuseIfSetupComplete` now also refuses when an admin user already exists (belt-and-suspenders defense in depth).
- New one-shot setup token: backend generates a 32-byte hex token at startup when no config exists, writes it to `data/setup.token` (mode 0600), and logs it. `/api/setup/initialize` requires the token in the request body and verifies it timing-safely. The token file is deleted on successful init so it cannot be replayed.
- Frontend OOBE wizard polls a new `/api/setup/token-status` endpoint and conditionally renders a setup-token input on the final step. Complete-setup is disabled until the token is filled.
- Existing installs upgrading mid-OOBE (no token file present) still rely on the config + admin guards, so the change is non-breaking.

Closes ticket #687.

## Test plan
- [ ] Fresh install: starting backend with no `data/config.json` writes `data/setup.token` and logs the token.
- [ ] OOBE wizard renders the Setup Token field on step 3, refuses to submit until filled.
- [ ] `/api/setup/initialize` rejects (401) with missing/wrong token; succeeds with the correct one.
- [ ] After successful init, `data/setup.token` is gone and `/api/setup/token-status` returns `{ tokenRequired: false }`.
- [ ] Re-calling `/api/setup/initialize` after init returns 403 (config guard).
- [ ] Manually deleting `data/config.json` post-init still 403s (admin-user guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)