### PR TITLE
feat(admin): inline photo title edit in list view (ticket #695)

### DIFF
--- a/frontend/src/components/AdminPortal/AlbumsManager.css
+++ b/frontend/src/components/AdminPortal/AlbumsManager.css
@@ -1034,6 +1034,37 @@
   text-overflow: ellipsis;
 }
 
+/* Ticket #695 — inline title edit affordance in list view. */
+.title-text.editable {
+  cursor: text;
+  border-radius: 4px;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  transition: background 0.15s ease;
+}
+
+.title-text.editable:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.list-item-title-input {
+  width: 100%;
+  font-size: 1rem;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--primary-color, #4ade80);
+  border-radius: 4px;
+  padding: 4px 8px;
+  outline: none;
+  font-family: inherit;
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.12);
+}
+
+.list-item-title-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .status-text {
   font-size: 0.75rem;
   color: #9ca3af;

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumContentPanel.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumContentPanel.tsx
@@ -44,6 +44,7 @@ interface AlbumContentPanelProps {
   onPhotoDragStart: (event: any, setActiveId?: (id: string | null) => void) => void;
   onPhotoDragEnd: (event: any, setActiveId?: (id: string | null) => void) => void;
   onOpenEditModal: (photo: Photo) => void;
+  onUpdatePhotoMetadata: (filename: string, newTitle: string, newDescription: string) => Promise<boolean>;
   onDeletePhoto: (album: string, filename: string, photoTitle?: string, thumbnail?: string, mediaType?: 'photo' | 'video') => void;
   onBulkDeletePhotos: (photoIds: string[], onCompleted?: (deletedIds: string[]) => void) => void;
   onRetryOptimization?: (album: string, filename: string) => void;
@@ -86,6 +87,7 @@ const AlbumContentPanel: React.FC<AlbumContentPanelProps> = ({
   onPhotoDragStart,
   onPhotoDragEnd,
   onOpenEditModal,
+  onUpdatePhotoMetadata,
   onDeletePhoto,
   onBulkDeletePhotos,
   onRetryOptimization,
@@ -315,6 +317,7 @@ const AlbumContentPanel: React.FC<AlbumContentPanelProps> = ({
           onPhotoDragStart={onPhotoDragStart}
           onPhotoDragEnd={onPhotoDragEnd}
           onOpenEditModal={onOpenEditModal}
+          onUpdatePhotoMetadata={onUpdatePhotoMetadata}
           onDeletePhoto={onDeletePhoto}
           onRetryOptimization={onRetryOptimization}
           onRetryAI={onRetryAI}

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumContentPanelGrid.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumContentPanelGrid.tsx
@@ -33,6 +33,7 @@ interface AlbumContentPanelGridProps {
   onPhotoDragStart: (event: any, setActiveId?: (id: string | null) => void) => void;
   onPhotoDragEnd: (event: any, setActiveId?: (id: string | null) => void) => void;
   onOpenEditModal: (photo: Photo) => void;
+  onUpdatePhotoMetadata: (filename: string, newTitle: string, newDescription: string) => Promise<boolean>;
   onDeletePhoto: (album: string, filename: string, photoTitle?: string, thumbnail?: string, mediaType?: 'photo' | 'video') => void;
   onRetryOptimization?: (album: string, filename: string) => void;
   onRetryAI?: (album: string, filename: string) => void;
@@ -56,6 +57,7 @@ const AlbumContentPanelGrid: React.FC<AlbumContentPanelGridProps> = ({
   onPhotoDragStart,
   onPhotoDragEnd,
   onOpenEditModal,
+  onUpdatePhotoMetadata,
   onDeletePhoto,
   onRetryOptimization,
   onRetryAI,
@@ -311,6 +313,7 @@ const AlbumContentPanelGrid: React.FC<AlbumContentPanelGridProps> = ({
                   key={photo.id}
                   photo={photo}
                   onEdit={onOpenEditModal}
+                  onUpdatePhotoMetadata={onUpdatePhotoMetadata}
                   onDelete={onDeletePhoto}
                   deletingPhotoId={deletingPhotoId}
                   canEdit={canEdit && !hasActiveUploads}

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumListItem.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumListItem.tsx
@@ -11,11 +11,13 @@ interface AlbumListItemProps {
   photo?: Photo;
   uploadingImage?: UploadingImage;
   uploadingIndex?: number;
-  
+
   // Handlers
   onEdit: (photo: Photo) => void;
   onDelete: (album: string, filename: string, photoTitle: string, thumbnail: string, mediaType?: 'photo' | 'video') => void;
-  
+  // Inline title save (ticket #695). Optional so legacy callers (e.g. uploading rows) work without it.
+  onUpdatePhotoMetadata?: (filename: string, newTitle: string, newDescription: string) => Promise<boolean>;
+
   // State
   deletingPhotoId: string | null;
   canEdit: boolean;
@@ -32,6 +34,7 @@ export const AlbumListItem: React.FC<AlbumListItemProps> = ({
   uploadingIndex,
   onEdit,
   onDelete,
+  onUpdatePhotoMetadata,
   deletingPhotoId,
   canEdit,
   selectMode = false,
@@ -52,7 +55,80 @@ export const AlbumListItem: React.FC<AlbumListItemProps> = ({
   const thumbnailUrl = photoData?.thumbnail || '';
   
   const isDeleting = deletingPhotoId === photoId;
-  
+
+  // Inline title edit (ticket #695) — mirrors the album-name pattern from AlbumContentPanelHeader.
+  // Only available for saved photos; rows that are still uploading or that lack a save handler
+  // fall back to read-only display.
+  const canInlineEdit = !!(
+    photoData?.id && onUpdatePhotoMetadata && canEdit && !isUploading && !selectMode
+  );
+  const [isEditingTitle, setIsEditingTitle] = React.useState(false);
+  const [editedTitle, setEditedTitle] = React.useState(title);
+  const [isSavingTitle, setIsSavingTitle] = React.useState(false);
+  const titleInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Reset edit state if the photo's title changes from outside (e.g. SSE update).
+  React.useEffect(() => {
+    if (!isEditingTitle) {
+      setEditedTitle(title);
+    }
+  }, [title, isEditingTitle]);
+
+  // Focus + select-all when entering edit mode so typing replaces the title immediately.
+  React.useEffect(() => {
+    if (isEditingTitle && titleInputRef.current) {
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [isEditingTitle]);
+
+  const handleStartTitleEdit = () => {
+    if (!canInlineEdit) return;
+    setEditedTitle(title);
+    setIsEditingTitle(true);
+  };
+
+  const handleCancelTitleEdit = () => {
+    setIsEditingTitle(false);
+    setEditedTitle(title);
+  };
+
+  const handleSaveTitleEdit = async () => {
+    // Guard against double-fire: Enter triggers save → state flips → blur on unmount
+    // would otherwise call this again with the same edited value.
+    if (isSavingTitle || !isEditingTitle) return;
+    if (!photoData || !onUpdatePhotoMetadata) {
+      setIsEditingTitle(false);
+      return;
+    }
+    const trimmed = editedTitle.trim();
+    // No-op when unchanged or empty — empty would clobber the existing title.
+    if (!trimmed || trimmed === title) {
+      setIsEditingTitle(false);
+      setEditedTitle(title);
+      return;
+    }
+    setIsSavingTitle(true);
+    try {
+      const success = await onUpdatePhotoMetadata(filename, trimmed, photoData.description ?? '');
+      if (success) {
+        setIsEditingTitle(false);
+      }
+    } finally {
+      setIsSavingTitle(false);
+    }
+  };
+
+  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSaveTitleEdit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancelTitleEdit();
+    }
+  };
+
   // Drag and drop
   const {
     attributes,
@@ -153,8 +229,34 @@ export const AlbumListItem: React.FC<AlbumListItemProps> = ({
       <div className="list-item-title">
         {statusText ? (
           <div className="status-text">{statusText}</div>
+        ) : isEditingTitle ? (
+          <input
+            ref={titleInputRef}
+            type="text"
+            className="list-item-title-input"
+            value={editedTitle}
+            onChange={(e) => setEditedTitle(e.target.value)}
+            onKeyDown={handleTitleKeyDown}
+            onBlur={handleSaveTitleEdit}
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            disabled={isSavingTitle}
+            maxLength={200}
+          />
         ) : (
-          <div className="title-text">{title}</div>
+          <div
+            className={`title-text ${canInlineEdit ? 'editable' : ''}`}
+            onDoubleClick={(e) => {
+              if (!canInlineEdit) return;
+              e.stopPropagation();
+              e.preventDefault();
+              handleStartTitleEdit();
+            }}
+            title={canInlineEdit ? t('albumsManager.doubleClickToEditTitle') : undefined}
+          >
+            {title}
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/AdminPortal/AlbumsManager/index.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/index.tsx
@@ -116,6 +116,7 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
     openEditModal,
     closeEditModal,
     handleEditSave,
+    updatePhotoMetadata,
   } = photoManagement;
   
   // Upload state (declare before useEffect that uses it)
@@ -871,6 +872,7 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
               onPhotoDragStart={(event, setActiveId) => photoManagement.handlePhotoDragStart(event, setActiveId)}
               onPhotoDragEnd={(event, setActiveId) => photoManagement.handlePhotoDragEnd(event, setActiveId)}
               onOpenEditModal={openEditModal}
+              onUpdatePhotoMetadata={updatePhotoMetadata}
               onDeletePhoto={photoHandlers.handleDeletePhoto}
               onBulkDeletePhotos={photoHandlers.handleBulkDeletePhotos}
               onRetryOptimization={photoHandlers.handleRetryOptimization}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -298,6 +298,7 @@
     "deleteAlbumConfirm": "Are you sure you want to delete the album \"{{albumName}}\"?\n\nThis will permanently delete all photos in this album.\n\nThis action cannot be undone.",
     "renameAlbum": "Rename Album",
     "clickToRename": "Click to rename album",
+    "doubleClickToEditTitle": "Double-click to edit title",
     "addDescription": "Add a description",
     "clickToEditDescription": "Click to edit description",
     "descriptionPlaceholder": "Add a description for this album (when, where, what it was for)\u2026",


### PR DESCRIPTION
## Summary
- Double-click a photo title in the admin album list view to edit it in place. `Enter` saves, `Escape` cancels, blur saves.
- Reuses the existing `PUT /api/image-metadata/:album/:filename` endpoint via `usePhotoManagement.updatePhotoMetadata`, threaded as a new `onUpdatePhotoMetadata` prop through `AlbumContentPanel` → `AlbumContentPanelGrid` → `AlbumListItem`. Passes the photo's existing description through unchanged so inline edits never clobber it.
- Pattern mirrors the album-name inline edit in `AlbumContentPanelHeader` (state + focus + select-all on enter, key handlers). The pencil-icon modal still opens the full title-and-description editor for cases that need both fields.

## Test plan
- [ ] Open admin → an album → switch to list view. Double-click a photo title; the row swaps to a focused, all-selected input.
- [ ] Edit and press `Enter` → toast confirms metadata updated, row shows the new title.
- [ ] Edit and press `Escape` → input collapses back to the original title with no save.
- [ ] Edit and click outside (blur) → save fires.
- [ ] Empty title or unchanged title is a no-op (no API call).
- [ ] In multi-select mode, double-click on title does not enter edit mode; row still toggles selection.
- [ ] Drag-and-drop reorder still works on the row (input's pointer events are stopped, but the title text outside edit mode allows drag).
- [ ] An uploading row (status text shown) cannot be edited inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)