### PR TITLE
Batch merge #65: #690, #689, #691, #692, #687

### DIFF
--- a/backend/src/database-users.ts
+++ b/backend/src/database-users.ts
@@ -103,6 +103,33 @@ export function getUserByGoogleId(googleId: string): User | null {
 }
 
 /**
+ * Check whether at least one admin user exists.
+ *
+ * Used by the OOBE setup guard as a belt-and-suspenders check on top of
+ * `getConfigExists()`: if an admin already exists, refuse to re-run the
+ * unauthenticated setup wizard regardless of config.json state. Safe to call
+ * before the users table is created — returns false when the table is missing,
+ * the database is unreachable, or any query error occurs.
+ */
+export function adminUserExists(): boolean {
+  try {
+    const db = getDatabase();
+    // Confirm the users table exists before querying (during OOBE the table
+    // is only created inside /api/setup/initialize).
+    const tableCheck = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+      .get();
+    if (!tableCheck) return false;
+    const row = db
+      .prepare("SELECT 1 FROM users WHERE role = 'admin' LIMIT 1")
+      .get();
+    return Boolean(row);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Create a new user
  */
 export function createUser(data: {

--- a/backend/src/email.ts
+++ b/backend/src/email.ts
@@ -27,19 +27,22 @@ export interface EmailConfig {
 
 /**
  * Translation helper function with variable interpolation
- * Replaces {{variable}} placeholders in translated strings
+ * Replaces {{variable}} placeholders in translated strings.
+ *
+ * Pass an explicit `locale` to render in the recipient's language. When omitted,
+ * falls back to the globally configured locale.
  */
-function t(key: string, variables?: Record<string, any>): string {
-  const locale = getGlobalLocale();
-  let translated = translateBackend(key, locale);
-  
+function t(key: string, variables?: Record<string, any>, locale?: string): string {
+  const effectiveLocale = locale ?? getGlobalLocale();
+  let translated = translateBackend(key, effectiveLocale);
+
   // Interpolate variables
   if (variables) {
     Object.entries(variables).forEach(([varName, value]) => {
       translated = translated.replace(new RegExp(`{{${varName}}}`, 'g'), String(value));
     });
   }
-  
+
   return translated;
 }
 
@@ -133,21 +136,21 @@ export async function sendInvitationEmail(
   const avatarPath = config.branding?.avatarPath || "/photos/avatar.png";
   const avatarUrl = `${frontendUrl}${avatarPath}`;
 
-  // Get translations for the global language setting
-  const locale = getGlobalLocale();
-  info(`[Email] Sending invitation email in language: ${locale}`);
+  // Render in the recipient's language (falls back to 'en' inside translateBackend)
+  info(`[Email] Sending invitation email in language: ${language}`);
+  const tr = (key: string, variables?: Record<string, any>) => t(key, variables, language);
 
   const mailOptions = {
     from: `"${emailConfig.from.name}" <${emailConfig.from.address}>`,
     to: toEmail,
-    subject: t('email.invitation.subject', { siteName }),
+    subject: tr('email.invitation.subject', { siteName }),
     html: `
       <!DOCTYPE html>
       <html>
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>${t('email.invitation.title', { siteName })}</title>
+        <title>${tr('email.invitation.title', { siteName })}</title>
         <style>
           body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -200,33 +203,33 @@ export async function sendInvitationEmail(
       <body>
         <div class="container">
           <img src="${avatarUrl}" alt="${siteName}" class="avatar" />
-          <h1>${t('email.invitation.title', { siteName })}</h1>
-          <p>${t('email.invitation.greeting')}</p>
-          <p>${t('email.invitation.body', { inviterName, siteName })}</p>
-          <p>${t('email.invitation.instructions')}</p>
-          <a href="${inviteUrl}" class="button">${t('email.invitation.button')}</a>
-          <p>${t('email.invitation.orCopyLink')}</p>
+          <h1>${tr('email.invitation.title', { siteName })}</h1>
+          <p>${tr('email.invitation.greeting')}</p>
+          <p>${tr('email.invitation.body', { inviterName, siteName })}</p>
+          <p>${tr('email.invitation.instructions')}</p>
+          <a href="${inviteUrl}" class="button">${tr('email.invitation.button')}</a>
+          <p>${tr('email.invitation.orCopyLink')}</p>
           <div class="code">${inviteUrl}</div>
-          <p><strong>${t('email.invitation.expiry')}</strong></p>
+          <p><strong>${tr('email.invitation.expiry')}</strong></p>
           <div class="footer">
-            <p>${t('email.invitation.footerIgnore')}</p>
-            <p>${t('email.invitation.footerAutomatic')}</p>
+            <p>${tr('email.invitation.footerIgnore')}</p>
+            <p>${tr('email.invitation.footerAutomatic')}</p>
           </div>
         </div>
       </body>
       </html>
     `,
     text: `
-${t('email.invitation.title', { siteName })}
+${tr('email.invitation.title', { siteName })}
 
-${t('email.invitation.body', { inviterName, siteName }).replace(/<\/?strong>/g, '')}
+${tr('email.invitation.body', { inviterName, siteName }).replace(/<\/?strong>/g, '')}
 
-${t('email.invitation.instructions')}
+${tr('email.invitation.instructions')}
 ${inviteUrl}
 
-${t('email.invitation.expiry')}
+${tr('email.invitation.expiry')}
 
-${t('email.invitation.footerIgnore')}
+${tr('email.invitation.footerIgnore')}
     `.trim(),
   };
 
@@ -275,25 +278,25 @@ export async function sendPasswordResetEmail(
   const avatarPath = config.branding?.avatarPath || "/photos/avatar.png";
   const avatarUrl = `${frontendUrl}${avatarPath}`;
 
-  // Get translations for the global language setting
-  const locale = getGlobalLocale();
-  info(`[Email] Sending password reset email in language: ${locale}`);
-  
-  const greeting = userName 
-    ? t('email.passwordReset.greeting', { userName })
-    : t('email.passwordReset.greetingFallback');
+  // Render in the recipient's language (falls back to 'en' inside translateBackend)
+  info(`[Email] Sending password reset email in language: ${language}`);
+  const tr = (key: string, variables?: Record<string, any>) => t(key, variables, language);
+
+  const greeting = userName
+    ? tr('email.passwordReset.greeting', { userName })
+    : tr('email.passwordReset.greetingFallback');
 
   const mailOptions = {
     from: `"${emailConfig.from.name}" <${emailConfig.from.address}>`,
     to: toEmail,
-    subject: t('email.passwordReset.subject', { siteName }),
+    subject: tr('email.passwordReset.subject', { siteName }),
     html: `
       <!DOCTYPE html>
       <html>
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>${t('email.passwordReset.title')} - ${siteName}</title>
+        <title>${tr('email.passwordReset.title')} - ${siteName}</title>
         <style>
           body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -352,45 +355,45 @@ export async function sendPasswordResetEmail(
       <body>
         <div class="container">
           <img src="${avatarUrl}" alt="${siteName}" class="avatar" />
-          <h1>${t('email.passwordReset.title')}</h1>
+          <h1>${tr('email.passwordReset.title')}</h1>
           <p>${greeting}</p>
-          <p>${t('email.passwordReset.body', { siteName })}</p>
-          <p>${t('email.passwordReset.instructions')}</p>
-          <a href="${resetUrl}" class="button">${t('email.passwordReset.button')}</a>
-          <p>${t('email.passwordReset.orCopyLink')}</p>
+          <p>${tr('email.passwordReset.body', { siteName })}</p>
+          <p>${tr('email.passwordReset.instructions')}</p>
+          <a href="${resetUrl}" class="button">${tr('email.passwordReset.button')}</a>
+          <p>${tr('email.passwordReset.orCopyLink')}</p>
           <div class="code">${resetUrl}</div>
           <div class="warning">
-            <strong>${t('email.passwordReset.warningTitle')}</strong>
+            <strong>${tr('email.passwordReset.warningTitle')}</strong>
             <ul>
-              <li>${t('email.passwordReset.warningExpiry')}</li>
-              <li>${t('email.passwordReset.warningIgnore')}</li>
-              <li>${t('email.passwordReset.warningNoChange')}</li>
+              <li>${tr('email.passwordReset.warningExpiry')}</li>
+              <li>${tr('email.passwordReset.warningIgnore')}</li>
+              <li>${tr('email.passwordReset.warningNoChange')}</li>
             </ul>
           </div>
           <div class="footer">
-            <p>${t('email.passwordReset.footerAutomatic')}</p>
-            <p>${t('email.passwordReset.footerContact')}</p>
+            <p>${tr('email.passwordReset.footerAutomatic')}</p>
+            <p>${tr('email.passwordReset.footerContact')}</p>
           </div>
         </div>
       </body>
       </html>
     `,
     text: `
-${t('email.passwordReset.subject', { siteName })}
+${tr('email.passwordReset.subject', { siteName })}
 
 ${greeting}
 
-${t('email.passwordReset.body', { siteName }).replace(/<\/?strong>/g, '')}
+${tr('email.passwordReset.body', { siteName }).replace(/<\/?strong>/g, '')}
 
-${t('email.passwordReset.instructions')}
+${tr('email.passwordReset.instructions')}
 ${resetUrl}
 
-${t('email.passwordReset.warningTitle')}
-- ${t('email.passwordReset.warningExpiry')}
-- ${t('email.passwordReset.warningIgnore')}
-- ${t('email.passwordReset.warningNoChange')}
+${tr('email.passwordReset.warningTitle')}
+- ${tr('email.passwordReset.warningExpiry')}
+- ${tr('email.passwordReset.warningIgnore')}
+- ${tr('email.passwordReset.warningNoChange')}
 
-${t('email.passwordReset.footerAutomatic')}
+${tr('email.passwordReset.footerAutomatic')}
     `.trim(),
   };
 
@@ -440,16 +443,16 @@ export async function sendTestEmail(toEmail: string, language: string = 'en'): P
   const config = getCurrentConfig();
   const siteName = config.branding?.siteName || "Galleria";
 
-  // Get translations for the global language setting
-  const locale = getGlobalLocale();
-  info(`[Email] Test email language: ${locale}`);
-  
+  // Render in the recipient's language (falls back to 'en' inside translateBackend)
+  info(`[Email] Test email language: ${language}`);
+  const tr = (key: string, variables?: Record<string, any>) => t(key, variables, language);
+
   const timestamp = new Date().toLocaleString();
 
   const mailOptions = {
     from: `"${emailConfig.from.name}" <${emailConfig.from.address}>`,
     to: toEmail,
-    subject: t('email.test.subject', { siteName }),
+    subject: tr('email.test.subject', { siteName }),
     html: `
       <!DOCTYPE html>
       <html>
@@ -488,27 +491,27 @@ export async function sendTestEmail(toEmail: string, language: string = 'en'): P
       </head>
       <body>
         <div class="container">
-          <div class="success">${t('email.test.success')}</div>
-          <h1>${t('email.test.title')}</h1>
-          <p>${t('email.test.body1')}</p>
-          <p>${t('email.test.body2', { siteName })}</p>
+          <div class="success">${tr('email.test.success')}</div>
+          <h1>${tr('email.test.title')}</h1>
+          <p>${tr('email.test.body1')}</p>
+          <p>${tr('email.test.body2', { siteName })}</p>
           <div class="footer">
-            <p>${t('email.test.footerTimestamp', { timestamp })}</p>
-            <p>${t('email.test.footerIgnore')}</p>
+            <p>${tr('email.test.footerTimestamp', { timestamp })}</p>
+            <p>${tr('email.test.footerIgnore')}</p>
           </div>
         </div>
       </body>
       </html>
     `,
     text: `
-${t('email.test.title')}
+${tr('email.test.title')}
 
-${t('email.test.success')} ${t('email.test.body1')}
+${tr('email.test.success')} ${tr('email.test.body1')}
 
-${t('email.test.body2', { siteName }).replace(/<\/?strong>/g, '')}
+${tr('email.test.body2', { siteName }).replace(/<\/?strong>/g, '')}
 
-${t('email.test.footerTimestamp', { timestamp })}
-${t('email.test.footerIgnore')}
+${tr('email.test.footerTimestamp', { timestamp })}
+${tr('email.test.footerIgnore')}
     `.trim(),
   };
 

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1374,6 +1374,13 @@ router.post('/passkey/auth-verify', async (req: Request, res: Response) => {
 
     const { user, passkey } = result;
 
+    // Reject deactivated accounts before doing any crypto work. Mirrors the
+    // is_active gate in the credential /login handler so that disabling a user
+    // also revokes their passkey-based access.
+    if (!user.is_active) {
+      return res.status(401).json({ error: 'Account is disabled' });
+    }
+
     // Verify authentication
     const verification = await verifyPasskeyAuthentication(
       credential,

--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -69,58 +69,70 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ * Pipe an HTTPS response through gunzip into a file using stream/promises
+ * pipeline(). pipeline() propagates errors from every stream in the chain
+ * (including socket resets on the response and truncated/non-gzip bodies on
+ * gunzip), ensures the destination is closed, and lets us unlink any partial
+ * file on failure. Returns true on success, false on failure.
+ */
+async function pipeResponseToGunzippedFile(
+  response: import('http').IncomingMessage,
+  dbPath: string
+): Promise<boolean> {
+  const gunzip = createGunzip();
+  const fileStream = createWriteStream(dbPath);
+  try {
+    await pipeline(response, gunzip, fileStream);
+    info('[Setup] GeoIP database downloaded successfully');
+    return true;
+  } catch (err) {
+    error('[Setup] Failed to download GeoIP database stream:', err);
+    // Clean up partial file (best-effort; ignore unlink errors so we always
+    // resolve the outer Promise).
+    await fs.promises.unlink(dbPath).catch(() => undefined);
+    return false;
+  }
+}
+
+/**
  * Download GeoIP database for location lookup
  * Uses DB-IP's free database (no registration required)
  */
 async function downloadGeoIPDatabase(dataDir: string): Promise<boolean> {
   try {
     const dbPath = path.join(dataDir, 'GeoLite2-City.mmdb');
-    
+
     // Skip if already exists
     if (fs.existsSync(dbPath)) {
       info('[Setup] GeoIP database already exists, skipping download');
       return true;
     }
-    
+
     info('[Setup] Downloading GeoIP database...');
-    
+
     // Get current year and month for DB-IP URL
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
-    
+
     // DB-IP free database URL (updated monthly)
     const dbipUrl = `https://download.db-ip.com/free/dbip-city-lite-${year}-${month}.mmdb.gz`;
-    
+
     return new Promise((resolve) => {
       https.get(dbipUrl, (response) => {
         if (response.statusCode === 302 || response.statusCode === 301) {
           // Follow redirect
           const redirectUrl = response.headers.location;
+          // Drain the redirect response so the socket can be reused / freed.
+          response.resume();
           if (redirectUrl) {
             info('[Setup] Following redirect to:', redirectUrl);
             https.get(redirectUrl, (redirectResponse) => {
               if (redirectResponse.statusCode === 200) {
-                const gunzip = createGunzip();
-                const fileStream = createWriteStream(dbPath);
-                
-                redirectResponse.pipe(gunzip).pipe(fileStream);
-                
-                fileStream.on('finish', () => {
-                  info('[Setup] GeoIP database downloaded successfully');
-                  resolve(true);
-                });
-                
-                fileStream.on('error', (err) => {
-                  error('[Setup] Failed to write GeoIP database:', err);
-                  // Clean up partial file
-                  if (fs.existsSync(dbPath)) {
-                    fs.unlinkSync(dbPath);
-                  }
-                  resolve(false);
-                });
+                pipeResponseToGunzippedFile(redirectResponse, dbPath).then(resolve);
               } else {
                 warn('[Setup] Failed to download GeoIP database (redirect response):', redirectResponse.statusCode);
+                redirectResponse.resume(); // discard body
                 resolve(false);
               }
             }).on('error', (err) => {
@@ -132,27 +144,11 @@ async function downloadGeoIPDatabase(dataDir: string): Promise<boolean> {
             resolve(false);
           }
         } else if (response.statusCode === 200) {
-          const gunzip = createGunzip();
-          const fileStream = createWriteStream(dbPath);
-          
-          response.pipe(gunzip).pipe(fileStream);
-          
-          fileStream.on('finish', () => {
-            info('[Setup] GeoIP database downloaded successfully');
-            resolve(true);
-          });
-          
-          fileStream.on('error', (err) => {
-            error('[Setup] Failed to write GeoIP database:', err);
-            // Clean up partial file
-            if (fs.existsSync(dbPath)) {
-              fs.unlinkSync(dbPath);
-            }
-            resolve(false);
-          });
+          pipeResponseToGunzippedFile(response, dbPath).then(resolve);
         } else {
           warn('[Setup] Failed to download GeoIP database, status:', response.statusCode);
           warn('[Setup] This is optional - location lookup will show "Location unknown"');
+          response.resume(); // discard body
           resolve(false);
         }
       }).on('error', (err) => {

--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -17,15 +17,26 @@ import { createGunzip } from "zlib";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendInstallationEvent } from '../utils/installation-analytics.js';
 import { getConfigExists } from '../config.js';
+import { adminUserExists } from '../database-users.js';
+import {
+  setupTokenExists,
+  verifySetupToken,
+  consumeSetupToken,
+} from '../utils/setup-token.js';
 
 const router = Router();
 
 /**
- * Guard for OOBE-only endpoints. Once config.json exists, the initial setup
- * has already been performed and these endpoints must refuse further calls —
- * otherwise an unauthenticated attacker could overwrite the session secret,
- * authorized emails, OAuth credentials, allowed origins/hosts, and provision
- * a new admin user (full account takeover). See ticket #533.
+ * Guard for OOBE-only endpoints. Once config.json exists OR an admin user is
+ * already provisioned, the initial setup has already been performed and these
+ * endpoints must refuse further calls — otherwise an unauthenticated attacker
+ * could overwrite the session secret, authorized emails, OAuth credentials,
+ * allowed origins/hosts, and provision a new admin user (full account
+ * takeover). See tickets #533 and #687.
+ *
+ * The admin-user check is belt-and-suspenders for the corner case where
+ * data/config.json is missing or got truncated but the user database still
+ * has an admin row.
  *
  * The post-OOBE equivalents live behind authenticated routes (e.g.
  * /api/branding/upload-avatar).
@@ -38,6 +49,17 @@ function refuseIfSetupComplete(
   if (getConfigExists()) {
     warn(
       `[Setup] Refusing ${req.method} ${req.path} — setup has already completed. ` +
+      `Source IP: ${req.ip || req.socket.remoteAddress}`
+    );
+    res.status(403).json({
+      error: "Setup has already completed. This endpoint is disabled.",
+      setupComplete: true,
+    });
+    return;
+  }
+  if (adminUserExists()) {
+    warn(
+      `[Setup] Refusing ${req.method} ${req.path} — an admin user already exists. ` +
       `Source IP: ${req.ip || req.socket.remoteAddress}`
     );
     res.status(403).json({
@@ -272,6 +294,20 @@ router.get("/status", async (req: Request, res: Response): Promise<void> => {
 });
 
 /**
+ * Report whether a one-shot setup token is required for /initialize.
+ *
+ * The OOBE wizard polls this endpoint to know whether to render the token
+ * input field. After /initialize completes the token file is deleted and
+ * this returns { tokenRequired: false }.
+ */
+router.get(
+  "/token-status",
+  (req: Request, res: Response): void => {
+    res.json({ tokenRequired: setupTokenExists() });
+  }
+);
+
+/**
  * Initialize configuration with user-provided values
  */
 router.post(
@@ -289,7 +325,36 @@ router.post(
         googleClientSecret,
         metaDescription,
         language,
+        setupToken,
       } = req.body;
+
+      // Verify the one-shot setup token. The token is generated on backend
+      // startup when no config.json exists and is written to data/setup.token
+      // (also logged to the console). It's consumed on successful init so it
+      // cannot be replayed. See utils/setup-token.ts and ticket #687.
+      if (setupTokenExists()) {
+        if (!verifySetupToken(setupToken)) {
+          warn(
+            `[Setup] Refusing /initialize — missing or invalid setup token. ` +
+            `Source IP: ${req.ip || req.socket.remoteAddress}`
+          );
+          res.status(401).json({
+            error:
+              "Invalid setup token. Copy the token from your server logs " +
+              "or from data/setup.token and paste it into the wizard.",
+          });
+          return;
+        }
+      } else {
+        // No token file means either an extremely old install pre-dating this
+        // change OR the token was already consumed. In the latter case the
+        // refuseIfSetupComplete guard above will already have rejected the
+        // request; reaching this branch means the install pre-dates the token
+        // mechanism, in which case the existing config / admin guards are
+        // still in effect and we accept the request to preserve OOBE for
+        // upgraders mid-flight.
+        info("[Setup] No setup token file present — proceeding with legacy guards.");
+      }
 
       // Validate required fields
       if (!siteName || !authorizedEmail || !authMethod) {
@@ -751,6 +816,9 @@ router.post(
       }).catch(err => {
         warn('[Setup] Failed to send setup_complete event:', err);
       });
+
+      // Consume (delete) the one-shot setup token so it cannot be replayed.
+      consumeSetupToken();
 
       res.json({
         success: true,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -102,6 +102,12 @@ if (getConfigExists()) {
   info(
     "[Server] Setup mode detected - skipping production security validation"
   );
+  // Generate the one-shot setup token that gates /api/setup/initialize.
+  // The operator copies it from logs (or data/setup.token) into the OOBE
+  // wizard. See utils/setup-token.ts and ticket #687.
+  void import("./utils/setup-token.js").then(({ ensureSetupToken }) => {
+    ensureSetupToken();
+  });
 }
 
 // Initialize database lazily (on first use) to avoid ESM/CommonJS issues

--- a/backend/src/services/milestone-tracker.ts
+++ b/backend/src/services/milestone-tracker.ts
@@ -31,37 +31,48 @@ export async function checkMilestones(): Promise<void> {
       const currentViews = data.views;
       const lastMilestone = data.lastMilestone;
 
-      // Check if any new milestones were reached
-      for (const milestone of MILESTONES) {
+      // Find the highest milestone the album has crossed since lastMilestone.
+      // Iterating in descending order and breaking on the first match ensures
+      // we send a single notification (and perform a single DB write) per tick
+      // even when an album's view count jumps past several thresholds at once.
+      let highestNewMilestone: number | null = null;
+      for (let i = MILESTONES.length - 1; i >= 0; i--) {
+        const milestone = MILESTONES[i];
         if (currentViews >= milestone && lastMilestone < milestone) {
-          // New milestone reached!
-          info(`[MilestoneTracker] 🎉 ${albumName} reached ${milestone} views!`);
-
-          // Send notification to all admins
-          const admins = getAllUsers().filter(u => u.role === 'admin');
-
-          for (const admin of admins) {
-            const title = await translateNotification('notifications.backend.albumViewMilestoneTitle', {
-              albumName,
-              milestone: milestone.toLocaleString()
-            });
-            const body = await translateNotification('notifications.backend.albumViewMilestoneBody', {
-              albumName,
-              milestone: milestone.toLocaleString()
-            });
-
-            await sendNotificationToUser(admin.id, {
-              title,
-              body,
-              tag: `milestone-${albumName}-${milestone}`,
-              requireInteraction: true
-            }, 'albumViewMilestone');
-          }
-
-          // Update milestone in database
-          updateAlbumMilestone(albumName, milestone);
-          milestonesReached++;
+          highestNewMilestone = milestone;
+          break;
         }
+      }
+
+      if (highestNewMilestone !== null) {
+        const milestone = highestNewMilestone;
+        // New milestone reached!
+        info(`[MilestoneTracker] 🎉 ${albumName} reached ${milestone} views!`);
+
+        // Send notification to all admins
+        const admins = getAllUsers().filter(u => u.role === 'admin');
+
+        for (const admin of admins) {
+          const title = await translateNotification('notifications.backend.albumViewMilestoneTitle', {
+            albumName,
+            milestone: milestone.toLocaleString()
+          });
+          const body = await translateNotification('notifications.backend.albumViewMilestoneBody', {
+            albumName,
+            milestone: milestone.toLocaleString()
+          });
+
+          await sendNotificationToUser(admin.id, {
+            title,
+            body,
+            tag: `milestone-${albumName}-${milestone}`,
+            requireInteraction: true
+          }, 'albumViewMilestone');
+        }
+
+        // Update milestone in database
+        updateAlbumMilestone(albumName, milestone);
+        milestonesReached++;
       }
     }
 

--- a/backend/src/utils/setup-token.ts
+++ b/backend/src/utils/setup-token.ts
@@ -1,0 +1,119 @@
+/**
+ * Setup Token
+ *
+ * One-shot token bound to the local installer that gates the unauthenticated
+ * /api/setup/initialize endpoint. Generated on backend startup whenever no
+ * config.json is present and consumed (deleted) once OOBE completes.
+ *
+ * Why this exists: even with refuseIfSetupComplete + admin-user guards, there
+ * is a brief window between server startup and the legitimate operator
+ * submitting the OOBE form during which an attacker who can reach the API
+ * could win the race. Requiring the token — readable only with filesystem
+ * access to the data directory — proves the request originated from the
+ * installer, not the open internet. See ticket #687.
+ */
+
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { DATA_DIR } from "../config.js";
+import { info, warn, error } from "./logger.js";
+
+const TOKEN_FILENAME = "setup.token";
+const TOKEN_BYTES = 32;
+
+function tokenPath(): string {
+  return path.join(DATA_DIR, TOKEN_FILENAME);
+}
+
+/**
+ * Generate (or rehydrate) the one-shot setup token. Idempotent: if the token
+ * file already exists, leaves it in place. Logs the token prominently so the
+ * operator can copy it from console / docker logs / pm2 logs.
+ */
+export function ensureSetupToken(): string | null {
+  try {
+    const filePath = tokenPath();
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    if (fs.existsSync(filePath)) {
+      const existing = fs.readFileSync(filePath, "utf8").trim();
+      if (existing) {
+        info("[SetupToken] Existing setup token detected at", filePath);
+        info("[SetupToken] Token (paste into the OOBE wizard):", existing);
+        return existing;
+      }
+    }
+
+    const token = crypto.randomBytes(TOKEN_BYTES).toString("hex");
+    fs.writeFileSync(filePath, token + "\n", { encoding: "utf8", mode: 0o600 });
+    // Some filesystems ignore the mode in writeFileSync — chmod explicitly.
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      /* best-effort */
+    }
+    info("============================================================");
+    info("[SetupToken] One-shot setup token generated.");
+    info("[SetupToken] Path :", filePath);
+    info("[SetupToken] Token:", token);
+    info("[SetupToken] Paste this into the OOBE wizard to finish setup.");
+    info("============================================================");
+    return token;
+  } catch (err) {
+    error("[SetupToken] Failed to generate setup token:", err);
+    return null;
+  }
+}
+
+/**
+ * Returns true when the on-disk setup token file exists.
+ */
+export function setupTokenExists(): boolean {
+  try {
+    return fs.existsSync(tokenPath());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify a candidate token against the on-disk setup token. Uses
+ * timing-safe comparison. Returns false when the file is missing, the
+ * candidate is empty, or the lengths/values disagree.
+ */
+export function verifySetupToken(candidate: unknown): boolean {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  try {
+    const filePath = tokenPath();
+    if (!fs.existsSync(filePath)) return false;
+    const expected = fs.readFileSync(filePath, "utf8").trim();
+    if (!expected) return false;
+    const a = Buffer.from(expected, "utf8");
+    const b = Buffer.from(candidate, "utf8");
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+  } catch (err) {
+    warn("[SetupToken] Verification error:", err);
+    return false;
+  }
+}
+
+/**
+ * Delete the on-disk setup token. Called after a successful /initialize so
+ * the token cannot be replayed.
+ */
+export function consumeSetupToken(): void {
+  try {
+    const filePath = tokenPath();
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+      info("[SetupToken] Consumed and removed:", filePath);
+    }
+  } catch (err) {
+    warn("[SetupToken] Failed to remove token file:", err);
+  }
+}

--- a/frontend/src/components/SetupWizard/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.tsx
@@ -38,6 +38,14 @@ export default function SetupWizard() {
   const [adminPasswordConfirm, setAdminPasswordConfirm] = useState('');
   const [showRestartModal, setShowRestartModal] = useState(false);
   const [animationBoost, setAnimationBoost] = useState(false);
+
+  // One-shot setup token (ticket #687). The backend writes a token to
+  // data/setup.token (and logs it) when no config.json is present; the
+  // operator pastes it here to authorize the unauthenticated /initialize
+  // call. We poll /api/setup/token-status on mount to decide whether to
+  // render the input.
+  const [setupToken, setSetupToken] = useState('');
+  const [tokenRequired, setTokenRequired] = useState(false);
   
   // Trigger animation boost when step changes
   useEffect(() => {
@@ -64,7 +72,21 @@ export default function SetupWizard() {
   // Check setup status on mount
   useEffect(() => {
     checkSetupStatus();
+    checkTokenStatus();
   }, []);
+
+  const checkTokenStatus = async () => {
+    try {
+      const response = await fetch(`${API_URL}/api/setup/token-status`);
+      if (!response.ok) return;
+      const data = await response.json();
+      setTokenRequired(Boolean(data.tokenRequired));
+    } catch (err) {
+      // Non-fatal: if the endpoint is unreachable we hide the field.
+      // The backend will still reject /initialize without a valid token.
+      warn('Setup token status check failed:', err);
+    }
+  };
 
   // Sync currentLanguage with i18n language changes and force re-render
   useEffect(() => {
@@ -176,6 +198,11 @@ export default function SetupWizard() {
       }
     }
 
+    if (tokenRequired && !setupToken.trim()) {
+      setError(t('oobe.setupTokenRequired', 'Setup token is required. Find it in your server logs or in data/setup.token.'));
+      return;
+    }
+
     try {
       setSubmitting(true);
       
@@ -195,6 +222,7 @@ export default function SetupWizard() {
           googleClientSecret: authMethod === 'google' ? googleClientSecret : undefined,
           metaDescription: metaDescription || t('oobe.siteDescriptionPlaceholder', { siteName }),
           language: currentLanguage,
+          setupToken: tokenRequired ? setupToken.trim() : undefined,
         }),
       });
 
@@ -653,6 +681,33 @@ export default function SetupWizard() {
                 {t('oobe.customizeDescription')}
               </p>
 
+              {tokenRequired && (
+                <div className="form-group">
+                  <label htmlFor="setupToken">
+                    {t('oobe.setupTokenLabel', 'Setup token')} *
+                    <span className="field-hint">
+                      {t(
+                        'oobe.setupTokenHint',
+                        'Copy the token from your server logs or from the data/setup.token file on the server.'
+                      )}
+                    </span>
+                  </label>
+                  <input
+                    type="text"
+                    id="setupToken"
+                    value={setupToken}
+                    onChange={(e) => setSetupToken(e.target.value)}
+                    placeholder={t(
+                      'oobe.setupTokenPlaceholder',
+                      'Paste the setup token here'
+                    )}
+                    autoComplete="off"
+                    spellCheck={false}
+                    required
+                  />
+                </div>
+              )}
+
               <div className="form-group">
                 <label htmlFor="avatar">
                   {t('oobe.avatarOptional')}
@@ -697,10 +752,10 @@ export default function SetupWizard() {
                 >
                   {t('oobe.backToAccount')}
                 </button>
-                <button 
+                <button
                   type="submit"
                   className="button button-primary"
-                  disabled={submitting}
+                  disabled={submitting || (tokenRequired && !setupToken.trim())}
                 >
                   {submitting ? t('oobe.settingUp') : t('oobe.completeSetup')}
                 </button>


### PR DESCRIPTION
Combines 5 tickets into a single deployment:

- **#690**: [bug-scan] Passkey login bypasses is_active check, deactivated users can still authenticate
- **#689**: [bug-scan] Milestone tracker re-notifies for every threshold below current view count on each run
- **#691**: [bug-scan] sendInvitationEmail and sendPasswordResetEmail ignore their `language` argument
- **#692**: [bug-scan] GeoIP database download has no error handler on response/gunzip streams
- **#687**: [security-audit] POST /api/setup/initialize is unauthenticated and re-runnable post-setup → full takeover

Tracking ticket: #760