### PR TITLE
Batch merge #84: #887, #889, #888, #886, #883, #891

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -394,6 +394,18 @@ const upload = multer({
   }
 });
 
+const cleanupUploadedTempFile = async (file?: Express.Multer.File): Promise<void> => {
+  if (!file?.path) {
+    return;
+  }
+
+  try {
+    await fs.promises.unlink(file.path);
+  } catch (err: any) {
+    error(`[Upload] Failed to clean up temp file ${file.path}:`, err.message);
+  }
+};
+
 // Get the current directory path for ES modules
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -857,14 +869,15 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
   try {
     const { album } = req.params;
     const { language = 'en' } = req.body;
+    const file = req.file as Express.Multer.File | undefined;
     
     const sanitizedAlbum = sanitizeName(album);
     if (!sanitizedAlbum) {
+      await cleanupUploadedTempFile(file);
       res.status(400).json({ error: 'Invalid album name' });
       return;
     }
 
-    const file = req.file as Express.Multer.File;
     if (!file) {
       res.status(400).json({ error: 'No file uploaded' });
       return;
@@ -873,6 +886,7 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
     // SECURITY: Sanitize filename to prevent path traversal attacks
     const sanitizedFilename = sanitizePhotoName(file.originalname);
     if (!sanitizedFilename) {
+      await cleanupUploadedTempFile(file);
       res.status(400).json({ error: 'Invalid filename. Use only alphanumeric characters, spaces, hyphens, underscores, and valid image/video extensions.' });
       return;
     }
@@ -881,6 +895,7 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
     const albumPath = path.join(photosDir, sanitizedAlbum);
     
     if (!fs.existsSync(albumPath)) {
+      await cleanupUploadedTempFile(file);
       res.status(404).json({ error: 'Album not found' });
       return;
     }
@@ -2015,4 +2030,3 @@ router.post('/:albumName/video/:filename/update-thumbnail', requireManager, asyn
 });
 
 export default router;
-

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -68,6 +68,7 @@ const SENSITIVE_CONFIG_PATHS: readonly string[] = [
   "environment.auth.sessionSecret",
   "environment.auth.google.clientSecret",
   "analytics.openobserve.password",
+  "analytics.openobserve.serviceToken",
   "openai.apiKey",
   "pushNotifications.vapidPrivateKey",
   "email.smtp.auth.user",

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -67,6 +67,7 @@ const SECRET_PLACEHOLDER = "__SECRET_UNCHANGED__";
 const SENSITIVE_CONFIG_PATHS: readonly string[] = [
   "environment.auth.sessionSecret",
   "environment.auth.google.clientSecret",
+  "analytics.openobserve.username",
   "analytics.openobserve.password",
   "analytics.openobserve.serviceToken",
   "openai.apiKey",

--- a/backend/src/routes/preview-grid.ts
+++ b/backend/src/routes/preview-grid.ts
@@ -98,6 +98,56 @@ interface PhotoGridOptions {
   photos: Array<{ filename: string }>;
 }
 
+type AlbumAccess =
+  | { allowed: true; reason: "published" | "authenticated" | "share-link" }
+  | { allowed: false; status: 404 | 403; message: string };
+
+/**
+ * Check album access using the same policy as album/video/optimized media:
+ * published albums are public, authenticated users can access private albums,
+ * and valid unexpired share links grant access only to their target album.
+ */
+function checkAlbumAccess(req: Request, albumName: string): AlbumAccess {
+  const albumState = getAlbumState(albumName);
+
+  if (!albumState) {
+    return { allowed: false, status: 404, message: "Album not found" };
+  }
+
+  if (albumState.published) {
+    return { allowed: true, reason: "published" };
+  }
+
+  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
+  if (isAuthenticated) {
+    return { allowed: true, reason: "authenticated" };
+  }
+
+  const shareKeyParam = req.query.key;
+  const shareKey = Array.isArray(shareKeyParam) ? shareKeyParam[0] : shareKeyParam;
+
+  if (shareKey && typeof shareKey === "string" && /^[a-f0-9]{64}$/i.test(shareKey)) {
+    const shareLink = getShareLinkBySecret(shareKey);
+    if (shareLink && shareLink.album === albumName && !isShareLinkExpired(shareLink)) {
+      return { allowed: true, reason: "share-link" };
+    }
+  }
+
+  return { allowed: false, status: 403, message: "Access denied" };
+}
+
+function setAlbumGridCacheHeaders(res: Response, albumName: string, fileCount: number, accessReason: AlbumAccess & { allowed: true }): void {
+  const cacheControl = accessReason.reason === "authenticated"
+    ? "private, no-store"
+    : "public, max-age=3600";
+
+  res.set({
+    'Content-Type': 'image/jpeg',
+    'Cache-Control': cacheControl,
+    'ETag': `"grid-${albumName}-${fileCount}"`,
+  });
+}
+
 /**
  * Load and resize a single photo for grid cell
  */
@@ -254,11 +304,9 @@ router.get("/album/:albumName", async (req: Request, res: Response): Promise<voi
       return;
     }
 
-    // Only expose previews for albums that are actually published. Unpublished
-    // albums must not be scrape-able by guessing directory names.
-    const albumState = getAlbumState(sanitizedAlbum);
-    if (!albumState || !albumState.published) {
-      res.status(404).json({ error: "Album not found" });
+    const access = checkAlbumAccess(req, sanitizedAlbum);
+    if (!access.allowed) {
+      res.status(access.status).json({ error: access.message });
       return;
     }
 
@@ -287,12 +335,7 @@ router.get("/album/:albumName", async (req: Request, res: Response): Promise<voi
       photos: files
     });
 
-    // Set cache headers (cache for 1 hour)
-    res.set({
-      'Content-Type': 'image/jpeg',
-      'Cache-Control': 'public, max-age=3600',
-      'ETag': `"grid-${sanitizedAlbum}-${files.length}"`,
-    });
+    setAlbumGridCacheHeaders(res, sanitizedAlbum, files.length, access);
 
     res.send(gridBuffer);
   } catch (err) {

--- a/backend/src/routes/video.ts
+++ b/backend/src/routes/video.ts
@@ -26,6 +26,34 @@ const sanitizePath = (name: string): string | null => {
   return name;
 };
 
+const getShareKey = (req: Request): string | null => {
+  const shareKeyParam = req.query.key;
+  const shareKey = Array.isArray(shareKeyParam) ? shareKeyParam[0] : shareKeyParam;
+
+  if (shareKey && typeof shareKey === 'string' && /^[a-f0-9]{64}$/i.test(shareKey)) {
+    return shareKey;
+  }
+
+  return null;
+};
+
+const appendShareKeyToPlaylist = (playlist: string, shareKey: string): string => {
+  const encodedShareKey = encodeURIComponent(shareKey);
+
+  return playlist
+    .split('\n')
+    .map((line) => {
+      const trimmedLine = line.trim();
+      if (!trimmedLine || trimmedLine.startsWith('#') || /[?&]key=/.test(trimmedLine)) {
+        return line;
+      }
+
+      const separator = trimmedLine.includes('?') ? '&' : '?';
+      return `${line}${separator}key=${encodedShareKey}`;
+    })
+    .join('\n');
+};
+
 /**
  * Check if user has access to album (authenticated, published, or valid share link)
  */
@@ -34,14 +62,12 @@ const hasAlbumAccess = (req: Request, album: string): boolean => {
   const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
   
   // Check for share link in query parameter
-  // Note: req.query.key can be a string OR an array if multiple keys are provided
-  const shareKeyParam = req.query.key;
-  const shareKey = Array.isArray(shareKeyParam) ? shareKeyParam[0] : shareKeyParam;
+  const shareKey = getShareKey(req);
   let hasValidShareLink = false;
   
   info(`[Video] Access check: album=${album}, shareKey=${shareKey ? String(shareKey).substring(0, 16) + '...' : 'none'}, isAuth=${isAuthenticated}`);
   
-  if (shareKey && typeof shareKey === 'string' && /^[a-f0-9]{64}$/i.test(shareKey)) {
+  if (shareKey) {
     const shareLink = getShareLinkBySecret(shareKey);
     info(`[Video] Share link lookup: found=${!!shareLink}, match=${shareLink?.album === album}, expired=${shareLink ? isShareLinkExpired(shareLink) : 'N/A'}`);
     if (shareLink && shareLink.album === album && !isShareLinkExpired(shareLink)) {
@@ -143,7 +169,13 @@ const serveMasterPlaylist = async (req: Request, res: Response, album: string, f
       res.setHeader('Access-Control-Allow-Credentials', 'true');
     }
 
-    // Send the master playlist file
+    const shareKey = getShareKey(req);
+    if (shareKey) {
+      const playlist = fs.readFileSync(masterPlaylistPath, 'utf8');
+      res.send(appendShareKeyToPlaylist(playlist, shareKey));
+      return;
+    }
+
     res.sendFile(masterPlaylistPath);
   } catch (err) {
     error('[Video] Failed to serve master playlist:', err);
@@ -237,7 +269,13 @@ router.get("/:album/:filename/:resolution/playlist.m3u8", async (req: Request, r
       res.setHeader('Access-Control-Allow-Credentials', 'true');
     }
 
-    // Send the playlist file
+    const shareKey = getShareKey(req);
+    if (shareKey) {
+      const playlist = fs.readFileSync(playlistPath, 'utf8');
+      res.send(appendShareKeyToPlaylist(playlist, shareKey));
+      return;
+    }
+
     res.sendFile(playlistPath);
   } catch (err) {
     error('[Video] Failed to serve playlist:', err);

--- a/frontend/src/components/AdminPortal/AlbumsManager.css
+++ b/frontend/src/components/AdminPortal/AlbumsManager.css
@@ -373,7 +373,7 @@
   justify-content: space-between;
   align-items: start;
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.35rem;
 }
 
 .album-card h4 {
@@ -398,6 +398,82 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.album-visibility-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.album-visibility-summary-card {
+  margin-bottom: 0.65rem;
+}
+
+.album-visibility-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.album-visibility-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35rem;
+  padding: 0.16rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.07);
+  color: #d1d5db;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.album-visibility-chip-public {
+  border-color: rgba(74, 222, 128, 0.35);
+  background: rgba(74, 222, 128, 0.12);
+  color: #86efac;
+}
+
+.album-visibility-chip-homepage {
+  border-color: rgba(96, 165, 250, 0.35);
+  background: rgba(96, 165, 250, 0.12);
+  color: #93c5fd;
+}
+
+.album-visibility-chip-folder {
+  border-color: rgba(168, 85, 247, 0.35);
+  background: rgba(168, 85, 247, 0.12);
+  color: #d8b4fe;
+}
+
+.album-visibility-chip-private {
+  border-color: rgba(251, 191, 36, 0.38);
+  background: rgba(251, 191, 36, 0.13);
+  color: #fde68a;
+}
+
+.album-visibility-chip-draft {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: #cbd5e1;
+}
+
+.album-visibility-text {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.5rem;
+  color: #9ca3af;
+  font-size: 0.72rem;
+  line-height: 1.3;
+}
+
+.album-visibility-link-count {
+  color: #fbbf24;
 }
 
 .album-rename-btn {
@@ -3079,4 +3155,3 @@ body.dragging .ghost-folder-tile {
   border-radius: 2px;
   transition: width 0.3s ease;
 }
-

--- a/frontend/src/components/AdminPortal/AlbumsManager.css
+++ b/frontend/src/components/AdminPortal/AlbumsManager.css
@@ -476,6 +476,36 @@
   color: #fbbf24;
 }
 
+.album-card-share-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  gap: 0.35rem;
+  margin-bottom: 0.65rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid rgba(251, 191, 36, 0.28);
+  background: rgba(251, 191, 36, 0.1);
+  color: #fde68a;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.album-card-share-btn:hover {
+  background: rgba(251, 191, 36, 0.16);
+  border-color: rgba(251, 191, 36, 0.42);
+  transform: translateY(-1px);
+}
+
+.album-card-share-btn svg {
+  display: block;
+  stroke: currentColor;
+}
+
 .album-rename-btn {
   position: absolute;
   top: 0.5rem;

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumContentPanelHeader.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumContentPanelHeader.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { UploadIcon, TrashIcon, LinkIcon, CloseIcon, EyeIcon, GridViewIcon, ListViewIcon, CheckmarkIcon } from '../../../icons';
 import { showToast } from '../../../../utils/toast';
 import { SITE_URL } from '../../../../config';
+import AlbumVisibilitySummary from './AlbumVisibilitySummary';
 
 type ViewMode = 'grid' | 'list';
 
@@ -46,7 +47,7 @@ const DESCRIPTION_MAX_LENGTH = 2000;
 const AlbumContentPanelHeader: React.FC<AlbumContentPanelHeaderProps> = ({
   selectedAlbum,
   localAlbums,
-  localFolders: _localFolders,
+  localFolders,
   albumPhotos,
   uploadingImages,
   viewMode,
@@ -320,6 +321,16 @@ const AlbumContentPanelHeader: React.FC<AlbumContentPanelHeaderProps> = ({
             </>
           )}
 
+          {/* Visibility summary — compact explanation of publish/homepage/folder/share state. */}
+          {!isEditingTitle && currentAlbum && (
+            <AlbumVisibilitySummary
+              album={currentAlbum}
+              folders={localFolders}
+              canManageShareLinks={canEdit}
+              variant="header"
+            />
+          )}
+
           {/* Album description (ticket #621) — editable inline below the title */}
           {!isEditingTitle && (
             isEditingDescription ? (
@@ -578,4 +589,3 @@ const AlbumContentPanelHeader: React.FC<AlbumContentPanelHeaderProps> = ({
 };
 
 export default AlbumContentPanelHeader;
-

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumVisibilitySummary.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/AlbumVisibilitySummary.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { API_URL } from '../../../../config';
+import { Album, AlbumFolder } from '../types';
+
+interface ShareLinkCounts {
+  active: number;
+  expired: number;
+}
+
+interface AlbumVisibilitySummaryProps {
+  album: Album;
+  folders: AlbumFolder[];
+  canManageShareLinks: boolean;
+  variant?: 'card' | 'header';
+}
+
+const getShareLinkText = (counts: ShareLinkCounts | null): string | null => {
+  if (!counts) return null;
+
+  const parts = [];
+  if (counts.active > 0) {
+    parts.push(`${counts.active} active`);
+  }
+  if (counts.expired > 0) {
+    parts.push(`${counts.expired} expired`);
+  }
+
+  return parts.length > 0 ? `${parts.join(', ')} link${counts.active + counts.expired === 1 ? '' : 's'}` : null;
+};
+
+const AlbumVisibilitySummary: React.FC<AlbumVisibilitySummaryProps> = ({
+  album,
+  folders,
+  canManageShareLinks,
+  variant = 'card',
+}) => {
+  const [shareLinkCounts, setShareLinkCounts] = React.useState<ShareLinkCounts | null>(null);
+  const isPublished = album.published !== false;
+  const showOnHomepage = album.show_on_homepage !== false;
+  const folder = album.folder_id != null ? folders.find(f => f.id === album.folder_id) : undefined;
+  const isFolderControlled = album.folder_id != null;
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (isPublished || !canManageShareLinks) {
+      setShareLinkCounts(null);
+      return;
+    }
+
+    fetch(`${API_URL}/api/share-links/album/${encodeURIComponent(album.name)}`, {
+      credentials: 'include',
+    })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Unable to load share links');
+        }
+        return response.json();
+      })
+      .then(data => {
+        if (cancelled) return;
+        const links = Array.isArray(data.shareLinks) ? data.shareLinks : [];
+        setShareLinkCounts({
+          active: links.filter((link: { expired?: boolean }) => !link.expired).length,
+          expired: links.filter((link: { expired?: boolean }) => link.expired).length,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setShareLinkCounts(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [album.name, canManageShareLinks, isPublished]);
+
+  const shareLinkText = getShareLinkText(shareLinkCounts);
+  const hasPrivateLink = Boolean(shareLinkCounts && shareLinkCounts.active > 0);
+  const folderName = folder?.name ? `"${folder.name}"` : 'the folder';
+  const summaryText = isFolderControlled
+    ? `Inherited from ${folderName}. Change visibility on the folder.`
+    : isPublished
+      ? showOnHomepage
+        ? 'Public gallery and homepage'
+        : 'Public gallery, hidden from homepage'
+      : hasPrivateLink
+        ? 'Unpublished; accessible through active private links.'
+        : 'Unpublished draft; use Share to create a private link.';
+
+  return (
+    <div className={`album-visibility-summary album-visibility-summary-${variant}`}>
+      <div className="album-visibility-chips" aria-label="Album visibility">
+        {isFolderControlled && (
+          <span className="album-visibility-chip album-visibility-chip-folder">Folder-controlled</span>
+        )}
+        {isPublished ? (
+          <>
+            <span className="album-visibility-chip album-visibility-chip-public">Public gallery</span>
+            {showOnHomepage && (
+              <span className="album-visibility-chip album-visibility-chip-homepage">Homepage</span>
+            )}
+          </>
+        ) : hasPrivateLink ? (
+          <span className="album-visibility-chip album-visibility-chip-private">Private link</span>
+        ) : (
+          <span className="album-visibility-chip album-visibility-chip-draft">Draft</span>
+        )}
+      </div>
+      <div className="album-visibility-text">
+        <span>{summaryText}</span>
+        {!isPublished && shareLinkText && (
+          <span className="album-visibility-link-count">{shareLinkText}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AlbumVisibilitySummary;

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/FoldersSection.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/FoldersSection.tsx
@@ -36,6 +36,7 @@ interface FoldersSectionProps {
   onAlbumMoveUp?: (albumName: string) => void;
   onAlbumMoveDown?: (albumName: string) => void;
   onAlbumMoveToFolder?: (albumName: string) => void;
+  onShareAlbum?: (albumName: string) => void;
   hasFolders: boolean;
   canEdit: boolean;
 }
@@ -68,6 +69,7 @@ const FoldersSection: React.FC<FoldersSectionProps> = ({
   onAlbumMoveUp,
   onAlbumMoveDown,
   onAlbumMoveToFolder,
+  onShareAlbum,
   hasFolders,
   canEdit,
 }) => {
@@ -107,6 +109,7 @@ const FoldersSection: React.FC<FoldersSectionProps> = ({
               onAlbumMoveUp={onAlbumMoveUp}
               onAlbumMoveDown={onAlbumMoveDown}
               onAlbumMoveToFolder={onAlbumMoveToFolder}
+              onShareAlbum={onShareAlbum}
               isFirst={index === 0}
               isLast={index === localFolders.length - 1}
               hasFolders={hasFolders}
@@ -120,4 +123,3 @@ const FoldersSection: React.FC<FoldersSectionProps> = ({
 };
 
 export default FoldersSection;
-

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/SortableAlbumCard.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/SortableAlbumCard.tsx
@@ -7,11 +7,13 @@ import { useRef, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Album } from '../types';
+import { Album, AlbumFolder } from '../types';
 import { FolderMinusIcon, UploadIcon, ChevronUpIcon, ChevronDownIcon, FolderArrowIcon } from '../../../icons';
+import AlbumVisibilitySummary from './AlbumVisibilitySummary';
 
 interface SortableAlbumCardProps {
   album: Album;
+  folders: AlbumFolder[];
   isSelected: boolean;
   isAnimating: boolean;
   isDragOver: boolean;
@@ -32,6 +34,7 @@ interface SortableAlbumCardProps {
 
 const SortableAlbumCard: React.FC<SortableAlbumCardProps> = ({
   album,
+  folders,
   isSelected,
   isAnimating,
   isDragOver,
@@ -228,6 +231,12 @@ const SortableAlbumCard: React.FC<SortableAlbumCardProps> = ({
           </span>
         </h4>
       </div>
+      <AlbumVisibilitySummary
+        album={album}
+        folders={folders}
+        canManageShareLinks={canEdit}
+        variant="card"
+      />
       {uploadProgress && uploadProgress.total > 0 ? (
         <div className="album-upload-progress">
           <div className="upload-progress-text">

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/SortableAlbumCard.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/SortableAlbumCard.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Album, AlbumFolder } from '../types';
-import { FolderMinusIcon, UploadIcon, ChevronUpIcon, ChevronDownIcon, FolderArrowIcon } from '../../../icons';
+import { FolderMinusIcon, UploadIcon, ChevronUpIcon, ChevronDownIcon, FolderArrowIcon, LinkIcon } from '../../../icons';
 import AlbumVisibilitySummary from './AlbumVisibilitySummary';
 
 interface SortableAlbumCardProps {
@@ -26,6 +26,7 @@ interface SortableAlbumCardProps {
   onMoveUp?: (albumName: string) => void;
   onMoveDown?: (albumName: string) => void;
   onMoveToFolder?: (albumName: string) => void;
+  onShareAlbum?: (albumName: string) => void;
   isFirst?: boolean;
   isLast?: boolean;
   hasFolders?: boolean;
@@ -47,6 +48,7 @@ const SortableAlbumCard: React.FC<SortableAlbumCardProps> = ({
   onMoveUp,
   onMoveDown,
   onMoveToFolder,
+  onShareAlbum,
   isFirst,
   isLast,
   hasFolders = false,
@@ -237,6 +239,24 @@ const SortableAlbumCard: React.FC<SortableAlbumCardProps> = ({
         canManageShareLinks={canEdit}
         variant="card"
       />
+      {canEdit && album.published === false && onShareAlbum && (
+        <button
+          className="album-card-share-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onShareAlbum(album.name);
+          }}
+          onTouchEnd={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            onShareAlbum(album.name);
+          }}
+          title={t('albumsManager.generateShareableLink')}
+        >
+          <LinkIcon width="14" height="14" />
+          <span>{t('photo.share')}</span>
+        </button>
+      )}
       {uploadProgress && uploadProgress.total > 0 ? (
         <div className="album-upload-progress">
           <div className="upload-progress-text">

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/SortableFolderCard.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/SortableFolderCard.tsx
@@ -296,6 +296,7 @@ const SortableFolderCard: React.FC<SortableFolderCardProps> = ({
             <SortableAlbumCard
               key={album.name}
               album={album}
+              folders={[folder]}
               isSelected={selectedAlbum === album.name}
               isAnimating={animatingAlbum === album.name}
               isDragOver={dragOverAlbum === album.name}
@@ -334,4 +335,3 @@ const SortableFolderCard: React.FC<SortableFolderCardProps> = ({
 };
 
 export default SortableFolderCard;
-

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/SortableFolderCard.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/SortableFolderCard.tsx
@@ -95,6 +95,7 @@ interface SortableFolderCardProps {
   onAlbumMoveUp?: (albumName: string) => void;
   onAlbumMoveDown?: (albumName: string) => void;
   onAlbumMoveToFolder?: (albumName: string) => void;
+  onShareAlbum?: (albumName: string) => void;
   isFirst?: boolean;
   isLast?: boolean;
   hasFolders: boolean;
@@ -129,6 +130,7 @@ const SortableFolderCard: React.FC<SortableFolderCardProps> = ({
   onAlbumMoveUp,
   onAlbumMoveDown,
   onAlbumMoveToFolder,
+  onShareAlbum,
   isFirst,
   isLast,
   hasFolders,
@@ -308,6 +310,7 @@ const SortableFolderCard: React.FC<SortableFolderCardProps> = ({
               onMoveUp={onAlbumMoveUp}
               onMoveDown={onAlbumMoveDown}
               onMoveToFolder={onAlbumMoveToFolder}
+              onShareAlbum={onShareAlbum}
               isFirst={index === 0}
               isLast={index === albums.length - 1}
               hasFolders={hasFolders}

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/UncategorizedSection.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/UncategorizedSection.tsx
@@ -145,6 +145,7 @@ const UncategorizedSection: React.FC<UncategorizedSectionProps> = ({
                 <SortableAlbumCard
                   key={album.name}
                   album={album}
+                  folders={[]}
                   isSelected={selectedAlbum === album.name}
                   isAnimating={animatingAlbum === album.name}
                   isDragOver={dragOverAlbum === album.name}
@@ -186,4 +187,3 @@ const UncategorizedSection: React.FC<UncategorizedSectionProps> = ({
 };
 
 export default UncategorizedSection;
-

--- a/frontend/src/components/AdminPortal/AlbumsManager/components/UncategorizedSection.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/components/UncategorizedSection.tsx
@@ -82,6 +82,7 @@ interface UncategorizedSectionProps {
   onAlbumMoveUp?: (albumName: string) => void;
   onAlbumMoveDown?: (albumName: string) => void;
   onAlbumMoveToFolder?: (albumName: string) => void;
+  onShareAlbum?: (albumName: string) => void;
   hasFolders: boolean;
   canEdit: boolean;
 }
@@ -109,6 +110,7 @@ const UncategorizedSection: React.FC<UncategorizedSectionProps> = ({
   onAlbumMoveUp,
   onAlbumMoveDown,
   onAlbumMoveToFolder,
+  onShareAlbum,
   hasFolders,
   canEdit,
 }) => {
@@ -157,6 +159,7 @@ const UncategorizedSection: React.FC<UncategorizedSectionProps> = ({
                   onMoveUp={onAlbumMoveUp}
                   onMoveDown={onAlbumMoveDown}
                   onMoveToFolder={onAlbumMoveToFolder}
+                  onShareAlbum={onShareAlbum}
                   isFirst={index === 0}
                   isLast={index === uncategorizedAlbums.length - 1}
                   hasFolders={hasFolders}

--- a/frontend/src/components/AdminPortal/AlbumsManager/index.tsx
+++ b/frontend/src/components/AdminPortal/AlbumsManager/index.tsx
@@ -443,6 +443,10 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
   const [activeFolderId, setActiveFolderId] = useState<number | null>(null);
   const [showShareModal, setShowShareModal] = useState(false);
   const [shareAlbumName, setShareAlbumName] = useState<string | null>(null);
+  const handleShareAlbum = (albumName: string) => {
+    setShareAlbumName(albumName);
+    setShowShareModal(true);
+  };
   
   // Move to Folder modal state
   const [showMoveToFolderModal, setShowMoveToFolderModal] = useState(false);
@@ -759,6 +763,7 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
             onAlbumMoveUp={mobileReorderHandlers.handleAlbumMoveUp}
             onAlbumMoveDown={mobileReorderHandlers.handleAlbumMoveDown}
             onAlbumMoveToFolder={handleOpenMoveToFolderModal}
+            onShareAlbum={handleShareAlbum}
             hasFolders={localFolders.length > 0}
             canEdit={canEdit}
           />
@@ -786,6 +791,7 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
             onAlbumMoveUp={mobileReorderHandlers.handleAlbumMoveUp}
             onAlbumMoveDown={mobileReorderHandlers.handleAlbumMoveDown}
             onAlbumMoveToFolder={handleOpenMoveToFolderModal}
+            onShareAlbum={handleShareAlbum}
             hasFolders={localFolders.length > 0}
             canEdit={canEdit}
           />
@@ -854,10 +860,7 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
               onDeleteAlbum={albumHandlers.handleDeleteAlbum}
               onRenameAlbum={albumHandlers.handleInlineRenameAlbum}
               onUpdateDescription={albumHandlers.handleUpdateAlbumDescription}
-              onShareAlbum={(albumName) => {
-                setShareAlbumName(albumName);
-                setShowShareModal(true);
-              }}
+              onShareAlbum={handleShareAlbum}
               onTogglePublished={albumHandlers.handleTogglePublished}
               onToggleHomepage={albumHandlers.handleToggleHomepage}
               onPreviewAlbum={(albumName) => {
@@ -953,4 +956,3 @@ const AlbumsManager: React.FC<AlbumsManagerProps> = ({
 };
 
 export default AlbumsManager;
-

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/ProfileSection.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/ProfileSection.tsx
@@ -125,8 +125,9 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
         headers: { "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({
-          secret: mfaSetup.secret,
+          setupToken: mfaSetup.setupToken,
           token: mfaToken,
+          backupCodes: mfaSetup.backupCodes,
         }),
       });
 
@@ -412,4 +413,3 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({
     </div>
   );
 };
-

--- a/frontend/src/components/AdminPortal/PhotosModal.css
+++ b/frontend/src/components/AdminPortal/PhotosModal.css
@@ -251,6 +251,20 @@
   flex-shrink: 0;
 }
 
+.album-visibility-summary-header {
+  width: 100%;
+  margin-top: 0.15rem;
+}
+
+.album-visibility-summary-header .album-visibility-chip {
+  font-size: 0.72rem;
+  min-height: 1.45rem;
+}
+
+.album-visibility-summary-header .album-visibility-text {
+  font-size: 0.82rem;
+}
+
 /* Album Title Editing */
 .album-title-edit-container {
   display: flex;

--- a/frontend/src/components/ContentModal/VideoPlayer.tsx
+++ b/frontend/src/components/ContentModal/VideoPlayer.tsx
@@ -50,8 +50,16 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
 
     if (onLoadStartRef.current) onLoadStartRef.current();
 
+    const appendSecretKey = (url: string): string => {
+      if (!secretKey) return url;
+      if (url.includes('key=')) return url;
+
+      const separator = url.includes('?') ? '&' : '?';
+      return `${url}${separator}key=${encodeURIComponent(secretKey)}`;
+    };
+
     // Construct master playlist URL
-    const masterPlaylistUrl = `${API_URL}/api/video/${encodeURIComponent(album)}/${encodeURIComponent(filename)}/master.m3u8`;
+    const masterPlaylistUrl = appendSecretKey(`${API_URL}/api/video/${encodeURIComponent(album)}/${encodeURIComponent(filename)}/master.m3u8`);
     console.log('[VideoPlayer] Master playlist URL:', masterPlaylistUrl);
 
     if (Hls.isSupported()) {
@@ -65,8 +73,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
           this.load = function(context: any, config: any, callbacks: any) {
             // Add secretKey to all video API requests
             if (secretKey && context.url && context.url.includes('/api/video/')) {
-              const separator = context.url.includes('?') ? '&' : '?';
-              context.url = `${context.url}${separator}key=${secretKey}`;
+              context.url = appendSecretKey(context.url);
             }
             return load(context, config, callbacks);
           };


### PR DESCRIPTION
Combines 6 tickets into a single deployment:

- **#887**: [bug-scan] Rejected uploads leave Multer temp files behind
- **#889**: [bug-scan] Profile MFA verification posts the wrong payload
- **#888**: [bug-scan] Safari share-link video playback drops the secret key
- **#886**: [security-audit] Public preview grid bypasses album publication checks
- **#883**: [security-audit] Authenticated viewers can read full secret-bearing config
- **#891**: [product-brainstorm] Add an album visibility summary to reduce publish confusion

Tracking ticket: #915