### PR TITLE
fix: avoid double query separator for exif fetch (ticket #1043)

### DIFF
--- a/frontend/src/components/ContentModal/ContentModal.tsx
+++ b/frontend/src/components/ContentModal/ContentModal.tsx
@@ -324,7 +324,7 @@ const ContentModal: React.FC<ContentModalProps> = ({
     try {
       const filename = photo.id.split('/').pop();
       const res = await fetchWithRateLimitCheck(
-        `${API_URL}/api/photos/${photo.album}/${filename}/exif${queryString ? '?' + queryString : ''}`
+        `${API_URL}/api/photos/${photo.album}/${filename}/exif${queryString}`
       );
       
       if (res.ok) {


### PR DESCRIPTION
Fixes the EXIF request URL construction so the existing query string is appended directly instead of adding a second question mark. This preserves cache busting and shared-album keys for EXIF requests.