### PR TITLE
fix: release native-HLS listener and src on VideoPlayer unmount (ticket #1045)

### DIFF
--- a/frontend/src/components/ContentModal/VideoPlayer.tsx
+++ b/frontend/src/components/ContentModal/VideoPlayer.tsx
@@ -48,6 +48,9 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     initializingRef.current = true;
     console.log('[VideoPlayer] Initializing for', filename);
 
+    // Track the native-HLS listener so cleanup can remove it
+    let onLoadedMetadata: (() => void) | null = null;
+
     if (onLoadStartRef.current) onLoadStartRef.current();
 
     const appendSecretKey = (url: string): string => {
@@ -162,9 +165,10 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
     } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
       console.log('[VideoPlayer] Using native HLS (Safari)');
       video.src = masterPlaylistUrl;
-      video.addEventListener('loadedmetadata', () => {
+      onLoadedMetadata = () => {
         if (onLoadedRef.current) onLoadedRef.current();
-      });
+      };
+      video.addEventListener('loadedmetadata', onLoadedMetadata);
     } else {
       console.error('[VideoPlayer] HLS not supported');
     }
@@ -175,6 +179,13 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({
         hlsRef.current.destroy();
         hlsRef.current = null;
       }
+      // Native-HLS (Safari) path: remove the listener and release the media element
+      if (onLoadedMetadata) {
+        video.removeEventListener('loadedmetadata', onLoadedMetadata);
+        onLoadedMetadata = null;
+      }
+      video.removeAttribute('src');
+      video.load();
     };
   }, [album, filename, videoTitle, secretKey]);
 


### PR DESCRIPTION
## Summary

Fixes a MEDIUM-severity resource leak in `frontend/src/components/ContentModal/VideoPlayer.tsx` (ticket #1045).

On Safari (`canPlayType('application/vnd.apple.mpegurl')`), the effect set `video.src` and attached an anonymous `loadedmetadata` listener, but the cleanup callback only destroyed the hls.js instance — it never removed the listener nor released the media element. Closing the modal mid-load (or switching videos, which re-runs the effect via the `filename` dep) left the element holding the closure and continuing network activity, compounding across opens.

## Changes

- Hoisted the native-HLS listener into a local `onLoadedMetadata` variable so cleanup can `removeEventListener` it.
- Cleanup now releases the media element for both code paths: `video.removeAttribute('src'); video.load();`.

## Test plan

- [ ] Safari: open a video, close the modal mid-load — confirm network activity stops and no stale `loadedmetadata` listener remains.
- [ ] Open multiple videos in sequence — confirm no listener/src accumulation.
- [ ] hls.js (Chrome/Firefox) path still plays and tears down cleanly.