### PR TITLE
fix: redirect video page errors after render (ticket #1044)

### DIFF
--- a/frontend/src/components/VideoPage.tsx
+++ b/frontend/src/components/VideoPage.tsx
@@ -84,13 +84,11 @@ const VideoPage: React.FC = () => {
     fetchVideo();
   }, [album, filename, t, isAuthenticated]);
 
-  const shouldRedirectTo404 = !loading && (Boolean(error) || !video);
-
   useEffect(() => {
-    if (shouldRedirectTo404) {
+    if (!loading && (error || !video)) {
       navigate('/404', { replace: true });
     }
-  }, [shouldRedirectTo404, navigate]);
+  }, [loading, error, video, navigate]);
 
   const handleBackToAlbum = () => {
     if (album) {
@@ -109,7 +107,7 @@ const VideoPage: React.FC = () => {
     );
   }
 
-  if (shouldRedirectTo404) {
+  if (error || !video) {
     return null;
   }
 

--- a/frontend/src/components/VideoPage.tsx
+++ b/frontend/src/components/VideoPage.tsx
@@ -82,7 +82,15 @@ const VideoPage: React.FC = () => {
     };
 
     fetchVideo();
-  }, [album, filename, t, isAuthenticated, navigate]);
+  }, [album, filename, t, isAuthenticated]);
+
+  const shouldRedirectTo404 = !loading && (Boolean(error) || !video);
+
+  useEffect(() => {
+    if (shouldRedirectTo404) {
+      navigate('/404', { replace: true });
+    }
+  }, [shouldRedirectTo404, navigate]);
 
   const handleBackToAlbum = () => {
     if (album) {
@@ -101,9 +109,7 @@ const VideoPage: React.FC = () => {
     );
   }
 
-  if (error || !video) {
-    // Redirect to 404 for any error
-    navigate('/404', { replace: true });
+  if (shouldRedirectTo404) {
     return null;
   }
 
@@ -136,4 +142,3 @@ const VideoPage: React.FC = () => {
 };
 
 export default VideoPage;
-


### PR DESCRIPTION
Moves the VideoPage 404 redirect out of the render body and into an effect keyed by the completed error/missing-video state, so React Router navigation is dispatched after commit.