### PR TITLE
fix: ContentGrid auto-open matches photo by exact id not endsWith (ticket #1048)

### DIFF
--- a/frontend/src/components/ContentGrid.tsx
+++ b/frontend/src/components/ContentGrid.tsx
@@ -155,8 +155,18 @@ const ContentGrid: React.FC<ContentGridProps> = ({ album, onAlbumNotFound, initi
       const urlParams = new URLSearchParams(location.search);
       const photoParam = urlParams.get('photo');
       if (photoParam) {
-        // Find photo by filename
-        const photo = allPhotos.find(p => p.id.endsWith(photoParam));
+        // Find photo by id. Ids are structured `<album>/<filename>`, so we must
+        // compare the album too — otherwise a filename shared across albums opens
+        // whichever photo happens to be first in array order (ticket #1048).
+        // On album pages the route's `album` matches the photo's source album, so an
+        // exact id comparison is correct. The homepage feed is sourced from multiple
+        // albums and the share link carries only the filename, so there we fall back
+        // to an exact filename match (still avoids endsWith partial-suffix collisions).
+        const photo = allPhotos.find(p =>
+          isHomepage
+            ? p.id.split('/').pop() === photoParam
+            : p.id === `${album}/${photoParam}`
+        );
         if (photo) {
           handlePhotoClick(photo);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galleria",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galleria",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "workspaces": [
         "frontend",
         "backend"
@@ -2934,28 +2934,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@simplewebauthn/server": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-9.0.3.tgz",
-      "integrity": "sha512-FMZieoBosrVLFxCnxPFD9Enhd1U7D8nidVDT4MsHc6l4fdVcjoeHjDueeXCloO1k5O/fZg1fsSXXPKbY2XTzDA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@hexagon/base64": "^1.1.27",
-        "@levischuck/tiny-cbor": "^0.2.2",
-        "@peculiar/asn1-android": "^2.3.10",
-        "@peculiar/asn1-ecc": "^2.3.8",
-        "@peculiar/asn1-rsa": "^2.3.8",
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
-        "@simplewebauthn/types": "^9.0.1",
-        "cross-fetch": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/@simplewebauthn/types": {
       "version": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galleria",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galleria",
-      "version": "1.1.2",
+      "version": "1.1.1",
       "workspaces": [
         "frontend",
         "backend"
@@ -2934,6 +2934,28 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-9.0.3.tgz",
+      "integrity": "sha512-FMZieoBosrVLFxCnxPFD9Enhd1U7D8nidVDT4MsHc6l4fdVcjoeHjDueeXCloO1k5O/fZg1fsSXXPKbY2XTzDA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@simplewebauthn/types": "^9.0.1",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@simplewebauthn/types": {
       "version": "9.0.1",


### PR DESCRIPTION
## Summary

`?photo=<filename>` auto-open in `ContentGrid` resolved the photo with `allPhotos.find(p => p.id.endsWith(photoParam))`. Since ids are structured `<album>/<filename>`, a filename shared across albums (e.g. `IMG_1234.jpg` in both `vacation/` and `family/`) matched whichever photo came first in array order — not the one the link author meant.

The fix compares the full id on album pages, where the route's `album` equals the photo's source album:

- **Album pages:** `p.id === \`${album}/${photoParam}\`` — exact match, resolves the collision.
- **Homepage:** the feed is sourced from multiple albums and the share link carries only the filename (base `/`), so the album can't be derived from the URL. There we fall back to an exact filename-segment match (`p.id.split('/').pop() === photoParam`), which still removes the `endsWith` partial-suffix false-match risk.

Branching on the existing `isHomepage` flag avoids regressing homepage auto-open, which the naive exact-id fix would have broken.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Two albums with a same-named photo: `/album/<album>?photo=<file>` opens the correct one
- [ ] Homepage `/?photo=<file>` still auto-opens