### PR TITLE
fix: require auth on image-metadata GET routes (ticket #1037)

### DIFF
--- a/backend/src/routes/image-metadata.ts
+++ b/backend/src/routes/image-metadata.ts
@@ -6,7 +6,7 @@
 import express from 'express';
 import { createRequire } from 'module';
 import { csrfProtection } from '../security.js';
-import { requireManager } from '../auth/middleware.js';
+import { requireAuth, requireManager } from '../auth/middleware.js';
 import { generateStaticJSONFiles } from './static-json.js';
 import { invalidateAlbumCache } from './albums.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
@@ -31,7 +31,7 @@ router.use(csrfProtection);
  * GET /api/image-metadata/:album/:filename
  * Get metadata for a specific image
  */
-router.get('/:album/:filename', async (req, res) => {
+router.get('/:album/:filename', requireAuth, async (req, res) => {
   try {
     const { album, filename } = req.params;
     const db = await getDbFunctions();
@@ -53,7 +53,7 @@ router.get('/:album/:filename', async (req, res) => {
  * GET /api/image-metadata/album/:album
  * Get all metadata for an album
  */
-router.get('/album/:album', async (req, res) => {
+router.get('/album/:album', requireAuth, async (req, res) => {
   try {
     const { album } = req.params;
     const db = await getDbFunctions();
@@ -69,7 +69,7 @@ router.get('/album/:album', async (req, res) => {
  * GET /api/image-metadata/all
  * Get all image metadata
  */
-router.get('/all', async (req, res) => {
+router.get('/all', requireManager, async (req, res) => {
   try {
     const db = await getDbFunctions();
     const metadata = db.getAllMetadata();


### PR DESCRIPTION
## Summary

Closes the unauthenticated data-leak in `backend/src/routes/image-metadata.ts` (security-audit ticket #1037, MEDIUM/auth).

The three GET handlers were mounted with only `csrfProtection` (a no-op for GET requests) and no auth, while the POST/PUT/DELETE handlers on the same router are gated by `requireManager`. This let any anonymous client read titles, descriptions, album names and filenames for **unpublished/private** albums — `/all` returns the entire `image_metadata` table via `db.getAllMetadata()`.

Changes:
- `GET /:album/:filename` → `requireAuth`
- `GET /album/:album` → `requireAuth`
- `GET /all` → `requireManager` (full-table dump, matches the mutating routes)

## Why this is safe for the public gallery

These GETs are not consumed by the public gallery — the only frontend caller is the admin-portal PUT in `usePhotoManagement.ts`. Public image titles are served from the pre-generated static JSON, not these endpoints, so gating them does not affect anonymous browsing.

## Test plan

- [ ] CI typecheck/build passes
- [ ] Authenticated admin/manager can still load metadata in the admin portal
- [ ] Anonymous request to `/api/image-metadata/all` returns 401