### PR TITLE
fix: clean up video HLS folders and JPG posters on photo delete (ticket #1039)

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -792,9 +792,10 @@ router.delete("/:album/photos/:photo", requireManager, async (req: Request, res:
 
     const photosDir = req.app.get("photosDir");
     const optimizedDir = req.app.get("optimizedDir");
-    
+    const videoDir = req.app.get("videoDir");
+
     const photoPath = path.join(photosDir, sanitizedAlbum, sanitizedPhoto);
-    
+
     if (!fs.existsSync(photoPath)) {
       res.status(404).json({ error: 'Photo not found' });
       return;
@@ -803,13 +804,31 @@ router.delete("/:album/photos/:photo", requireManager, async (req: Request, res:
     // Delete from photos directory
     fs.unlinkSync(photoPath);
 
-    // Delete from optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
-      const optimizedPath = path.join(optimizedDir, dir, sanitizedAlbum, sanitizedPhoto);
-      if (fs.existsSync(optimizedPath)) {
-        fs.unlinkSync(optimizedPath);
+    if (isVideoFile(sanitizedPhoto)) {
+      // Videos store their optimized posters as .jpg (not the original .mp4 name)
+      const posterName = sanitizedPhoto.replace(/\.[^.]+$/, '.jpg');
+      ['thumbnail', 'modal', 'download'].forEach(dir => {
+        const posterPath = path.join(optimizedDir, dir, sanitizedAlbum, posterName);
+        if (fs.existsSync(posterPath)) {
+          fs.unlinkSync(posterPath);
+        }
+      });
+
+      // Remove the per-video HLS output (master.m3u8, per-resolution playlists, .ts segments).
+      // The HLS folder is named with the full filename, matching processVideo / the video route.
+      if (videoDir) {
+        const hlsPath = path.join(videoDir, sanitizedAlbum, sanitizedPhoto);
+        fs.rmSync(hlsPath, { recursive: true, force: true });
       }
-    });
+    } else {
+      // Delete from optimized directories
+      ['thumbnail', 'modal', 'download'].forEach(dir => {
+        const optimizedPath = path.join(optimizedDir, dir, sanitizedAlbum, sanitizedPhoto);
+        if (fs.existsSync(optimizedPath)) {
+          fs.unlinkSync(optimizedPath);
+        }
+      });
+    }
 
     // Delete metadata from database
     const deleted = deleteImageMetadata(sanitizedAlbum, sanitizedPhoto);


### PR DESCRIPTION
## Summary

`DELETE /:album/photos/:photo` always treated the asset as a still image. For videos this meant:

- The per-video HLS output at `videoDir/<album>/<filename>/` (`master.m3u8`, per-resolution playlists, `.ts` segments — created by `processVideo`) was **never deleted**, leaking large amounts of disk on every video delete.
- The optimized poster variants were never removed, because video posters are written as `.jpg` (`filename.replace(/\.[^.]+$/, '.jpg')`), not under the original `.mp4` name — so the existing unlinks were silent no-ops.

The handler now branches on `isVideoFile(sanitizedPhoto)`:
- **Video:** unlinks the `.jpg` poster in `thumbnail`/`modal`/`download`, then `fs.rmSync(path.join(videoDir, album, filename), {recursive: true, force: true})` to remove the HLS folder.
- **Still image:** unchanged behavior.

### Note on the ticket

The ticket suggested the HLS folder is named with the basename-without-ext. I verified against `processVideo` (`utils/video-processor.ts:552`) and the serving route (`routes/video.ts:131`): the folder is named with the **full filename including extension**, so I used `sanitizedPhoto` directly. Posters do use the basename `.jpg`.

## Test plan

- [ ] Delete a video via the admin UI and confirm `data/video/<album>/<file>/` is removed and the `.jpg` posters are gone.
- [ ] Delete a still image and confirm existing behavior is unchanged.
- [ ] CI typecheck/tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)