### PR TITLE
fix: harden optimized image and setup routes (ticket #1590)

### DIFF
--- a/backend/src/routes/setup.ts
+++ b/backend/src/routes/setup.ts
@@ -3,7 +3,7 @@
  * Handles initial setup and configuration for first-time users
  */
 
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -37,6 +37,77 @@ const upload = multer({
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+type SetupChecks = {
+  configExists: boolean;
+  databaseExists: boolean;
+  photosDirExists: boolean;
+  optimizedDirExists: boolean;
+  hasPhotos: boolean;
+  isConfigured: boolean;
+};
+
+function getSetupState(): { setupComplete: boolean; checks: SetupChecks } {
+  const projectRoot = path.join(__dirname, "../../../");
+  const dataDir = process.env.DATA_DIR || path.join(projectRoot, "data");
+  const configPath = path.join(dataDir, "config.json");
+  const dbPath = path.join(dataDir, "gallery.db");
+  const photosDir = path.join(dataDir, "photos");
+  const optimizedDir = path.join(dataDir, "optimized");
+
+  const checks = {
+    configExists: fs.existsSync(configPath),
+    databaseExists: fs.existsSync(dbPath),
+    photosDirExists: fs.existsSync(photosDir),
+    optimizedDirExists: fs.existsSync(optimizedDir),
+    hasPhotos: false,
+    isConfigured: false,
+  };
+
+  // Check if photos directory has any albums
+  if (checks.photosDirExists) {
+    const entries = fs.readdirSync(photosDir, { withFileTypes: true });
+    checks.hasPhotos = entries.some((entry) => entry.isDirectory());
+  }
+
+  // Check if config is properly configured (not just example values)
+  if (checks.configExists) {
+    try {
+      const configContent = fs.readFileSync(configPath, "utf8");
+      const config = JSON.parse(configContent);
+
+      const hasValidAuth =
+        config.environment?.auth?.sessionSecret &&
+        config.environment.auth.sessionSecret !== "your-session-secret-here";
+      const hasValidBranding =
+        config.branding?.siteName && config.branding.siteName !== "Your Name";
+
+      checks.isConfigured = hasValidAuth && hasValidBranding;
+    } catch (err) {
+      checks.isConfigured = false;
+    }
+  }
+
+  const setupComplete =
+    checks.configExists && checks.databaseExists && checks.isConfigured;
+
+  return { setupComplete, checks };
+}
+
+function rejectIfSetupComplete(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const { setupComplete } = getSetupState();
+
+  if (setupComplete) {
+    res.status(409).json({ error: "Setup is already complete" });
+    return;
+  }
+
+  next();
+}
 
 /**
  * Download GeoIP database for location lookup
@@ -143,49 +214,7 @@ async function downloadGeoIPDatabase(dataDir: string): Promise<boolean> {
  */
 router.get("/status", async (req: Request, res: Response): Promise<void> => {
   try {
-    const projectRoot = path.join(__dirname, "../../../");
-    const dataDir = process.env.DATA_DIR || path.join(projectRoot, "data");
-    const configPath = path.join(dataDir, "config.json");
-    const dbPath = path.join(dataDir, "gallery.db");
-    const photosDir = path.join(dataDir, "photos");
-    const optimizedDir = path.join(dataDir, "optimized");
-
-    const checks = {
-      configExists: fs.existsSync(configPath),
-      databaseExists: fs.existsSync(dbPath),
-      photosDirExists: fs.existsSync(photosDir),
-      optimizedDirExists: fs.existsSync(optimizedDir),
-      hasPhotos: false,
-      isConfigured: false,
-    };
-
-    // Check if photos directory has any albums
-    if (checks.photosDirExists) {
-      const entries = fs.readdirSync(photosDir, { withFileTypes: true });
-      checks.hasPhotos = entries.some((entry) => entry.isDirectory());
-    }
-
-    // Check if config is properly configured (not just example values)
-    if (checks.configExists) {
-      try {
-        const configContent = fs.readFileSync(configPath, "utf8");
-        const config = JSON.parse(configContent);
-
-        // Check if critical fields are configured (not example values)
-        const hasValidAuth =
-          config.environment?.auth?.sessionSecret &&
-          config.environment.auth.sessionSecret !== "your-session-secret-here";
-        const hasValidBranding =
-          config.branding?.siteName && config.branding.siteName !== "Your Name";
-
-        checks.isConfigured = hasValidAuth && hasValidBranding;
-      } catch (err) {
-        checks.isConfigured = false;
-      }
-    }
-
-    const setupComplete =
-      checks.configExists && checks.databaseExists && checks.isConfigured;
+    const { setupComplete, checks } = getSetupState();
 
     // Only send installation_started event if setup is NOT complete (actual OOBE)
     if (!setupComplete) {
@@ -246,6 +275,7 @@ router.get("/status", async (req: Request, res: Response): Promise<void> => {
  */
 router.post(
   "/initialize",
+  rejectIfSetupComplete,
   async (req: Request, res: Response): Promise<void> => {
     try {
       const {
@@ -640,7 +670,7 @@ router.post(
         // Use the default Galleria logo (icon-512.png for best quality)
         const defaultIconPath = path.join(projectRoot, "config/icons/icon-512.png");
 
-        if (fs.existsSync(defaultIconPath)) {
+        if (fs.existsSync(defaultIconPath) && !fs.existsSync(avatarPath)) {
           // Copy as avatar.png
           await sharp(defaultIconPath)
             .resize(512, 512, { fit: 'cover' })
@@ -685,6 +715,8 @@ router.post(
           fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
 
           info("  ✓ Default avatar and icons set up successfully");
+        } else if (fs.existsSync(avatarPath)) {
+          info("  Custom avatar already exists, preserving it");
         } else {
           warn("  ⚠️ Default icon not found at:", defaultIconPath);
         }
@@ -755,6 +787,7 @@ router.post(
  */
 router.post(
   "/upload-avatar",
+  rejectIfSetupComplete,
   upload.single("avatar"),
   async (req: Request, res: Response): Promise<void> => {
     try {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -57,6 +57,60 @@ const imageCache = new Map<
 const IMAGE_CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 const IMAGE_CACHE_MAX_ITEMS = 2000; // Limit cache size (thumbnails + modals)
 
+function getOptimizedRelativePath(reqPath: string): string | null {
+  let decoded: string;
+
+  try {
+    decoded = decodeURIComponent(reqPath);
+  } catch {
+    return null;
+  }
+
+  if (decoded.includes("\0") || decoded.includes("\\")) {
+    return null;
+  }
+
+  return decoded.replace(/^[/\\]+/, "");
+}
+
+function isOptimizedCachePath(reqPath: string): boolean {
+  const relative = getOptimizedRelativePath(reqPath);
+
+  if (relative) {
+    return (
+      relative === "thumbnail" ||
+      relative === "modal" ||
+      relative.startsWith("thumbnail/") ||
+      relative.startsWith("modal/")
+    );
+  }
+
+  return reqPath.startsWith("/thumbnail") || reqPath.startsWith("/modal");
+}
+
+function safeOptimizedPath(
+  optimizedDir: string,
+  reqPath: string
+): string | null {
+  const relative = getOptimizedRelativePath(reqPath);
+
+  if (
+    !relative ||
+    (!relative.startsWith("thumbnail/") && !relative.startsWith("modal/"))
+  ) {
+    return null;
+  }
+
+  const root = path.resolve(optimizedDir);
+  const candidate = path.resolve(root, relative);
+
+  if (candidate !== root && !candidate.startsWith(root + path.sep)) {
+    return null;
+  }
+
+  return candidate;
+}
+
 // Import authentication middleware
 import { requireAdmin } from "./auth/middleware.ts";
 
@@ -529,11 +583,16 @@ const cacheImageMiddleware = (
 ) => {
   // When mounted under /optimized, req.path is relative to that mount point
   // So req.path will be /thumbnail/... or /modal/... (without /optimized prefix)
-  if (!req.path.startsWith("/thumbnail/") && !req.path.startsWith("/modal/")) {
+  if (!isOptimizedCachePath(req.path)) {
     return next();
   }
 
-  const imagePath = path.join(optimizedDir, req.path);
+  const imagePath = safeOptimizedPath(optimizedDir, req.path);
+  if (!imagePath) {
+    res.status(400).json({ error: "Invalid image path" });
+    return;
+  }
+
   const now = Date.now();
 
   // Check cache first
@@ -576,7 +635,13 @@ const cacheImageMiddleware = (
       timestamp: now,
     });
 
-    const sizeType = req.path.includes("/thumbnail/") ? "thumbnail" : "modal";
+    const cacheRelativePath = path.relative(
+      path.resolve(optimizedDir),
+      imagePath
+    );
+    const sizeType = cacheRelativePath.startsWith(`thumbnail${path.sep}`)
+      ? "thumbnail"
+      : "modal";
     debug(
       `[Cache] Cached ${sizeType}: ${path.basename(imagePath)} (${(
         data.length / 1024

--- a/frontend/src/components/SetupWizard/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard/SetupWizard.tsx
@@ -178,6 +178,27 @@ export default function SetupWizard() {
 
     try {
       setSubmitting(true);
+
+      // Upload the optional avatar before initialization; setup mutation routes
+      // are locked once the backend reports setup complete.
+      if (avatarFile) {
+        try {
+          const formData = new FormData();
+          formData.append('avatar', avatarFile);
+
+          const avatarResponse = await fetch(`${API_URL}/api/setup/upload-avatar`, {
+            method: 'POST',
+            body: formData,
+          });
+
+          if (!avatarResponse.ok) {
+            warn('Avatar upload failed, but continuing with setup');
+          }
+        } catch (err) {
+          warn('Avatar upload failed:', err);
+          // Don't fail the entire setup if avatar upload fails
+        }
+      }
       
       // Initialize the configuration with user account data
       const response = await fetch(`${API_URL}/api/setup/initialize`, {
@@ -202,26 +223,6 @@ export default function SetupWizard() {
 
       if (!response.ok) {
         throw new Error(data.error || 'Setup failed');
-      }
-
-      // If avatar was uploaded, save it
-      if (avatarFile) {
-        try {
-          const formData = new FormData();
-          formData.append('avatar', avatarFile);
-          
-          const avatarResponse = await fetch(`${API_URL}/api/setup/upload-avatar`, {
-            method: 'POST',
-            body: formData,
-          });
-          
-          if (!avatarResponse.ok) {
-            warn('Avatar upload failed, but continuing with setup');
-          }
-        } catch (err) {
-          warn('Avatar upload failed:', err);
-          // Don't fail the entire setup if avatar upload fails
-        }
       }
 
       setSuccess(t('oobe.completeHeading'));
@@ -755,4 +756,3 @@ export default function SetupWizard() {
     </div>
   );
 }
-


### PR DESCRIPTION
Fixes the optimized image cache path traversal by resolving thumbnail/modal cache paths under the optimized root before cache lookup or disk reads, and returns 400 for invalid cache paths. Also locks setup mutation routes after setup is complete and preserves first-run avatar uploads by uploading before initialization.\n\nOperational follow-up is still required: rotate exposed secrets and invalidate sessions because live exposure was confirmed.