### PR TITLE
fix: protect unpublished album read endpoints (ticket #1591)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "node --test --loader ts-node/esm src/utils/album-access.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test --loader ts-node/esm src/utils/album-access.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/albums.ts
+++ b/backend/src/routes/albums.ts
@@ -25,6 +25,7 @@ import {
   getAlbumsInFolder,
   incrementAlbumViewCount
 } from "../database.js";
+import { getAlbumAccess } from '../utils/album-access.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const router = Router();
@@ -318,20 +319,14 @@ const serveAlbumJSON = (req: Request, res: Response, albumName: string): void =>
     return;
   }
 
-  // Check if user is authenticated (Passport or credentials)
-  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
-  
-  // Check album published state
-  const albumState = getAlbumState(sanitizedAlbum);
-  
-  // Return 404 if album doesn't exist at all
-  if (!albumState) {
+  const access = getAlbumAccess(req, sanitizedAlbum);
+
+  if (!access.exists) {
     res.status(404).json({ error: "Album not found" });
     return;
   }
-  
-  // Return 403 if album exists but is unpublished and user is not authenticated
-  if (!albumState.published && !isAuthenticated) {
+
+  if (!access.allowed) {
     res.status(403).json({ error: "Access denied" });
     return;
   }
@@ -373,28 +368,24 @@ const serveAlbumPhotos = (req: Request, res: Response, albumName: string): void 
 
   const photosDir = req.app.get("photosDir");
   const albumPath = path.join(photosDir, sanitizedAlbum);
-  
-  // Check if album directory exists
-  if (!fs.existsSync(albumPath) || !fs.statSync(albumPath).isDirectory()) {
+
+  const access = getAlbumAccess(req, sanitizedAlbum);
+
+  if (!access.exists) {
     res.status(404).json({ error: "Album not found" });
     return;
   }
 
-  // Check if user is authenticated (Passport or credentials)
-  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
-  
-  // Check album published state
-  const albumState = getAlbumState(sanitizedAlbum);
-  
-  // Return 404 if album doesn't exist at all
-  if (!albumState) {
-    res.status(404).json({ error: "Album not found" });
+  if (!access.allowed) {
+    res.status(403).json({ error: "Access denied" });
     return;
   }
+
+  const albumState = access.albumState!;
   
-  // Return 403 if album exists but is unpublished and user is not authenticated
-  if (!albumState.published && !isAuthenticated) {
-    res.status(403).json({ error: "Access denied" });
+  // Check if album directory exists
+  if (!fs.existsSync(albumPath) || !fs.statSync(albumPath).isDirectory()) {
+    res.status(404).json({ error: "Album not found" });
     return;
   }
 
@@ -598,6 +589,18 @@ const servePhotoEXIF = async (req: Request, res: Response, albumName: string, fi
     return;
   }
 
+  const access = getAlbumAccess(req, sanitizedAlbum);
+
+  if (!access.exists) {
+    res.status(404).json({ error: "Image not found" });
+    return;
+  }
+
+  if (!access.allowed) {
+    res.status(403).json({ error: "Access denied" });
+    return;
+  }
+
   try {
     const photosDir = req.app.get("photosDir");
     const filePath = path.join(photosDir, sanitizedAlbum, sanitizedFilename);
@@ -642,6 +645,18 @@ const serveVideoMetadata = async (req: Request, res: Response, albumName: string
   // Ensure the filename has a video extension
   if (!/\.(mp4|mov|avi|mkv|webm)$/i.test(sanitizedFilename)) {
     res.status(400).json({ error: "Invalid video file" });
+    return;
+  }
+
+  const access = getAlbumAccess(req, sanitizedAlbum);
+
+  if (!access.exists) {
+    res.status(404).json({ error: "Video not found" });
+    return;
+  }
+
+  if (!access.allowed) {
+    res.status(403).json({ error: "Access denied" });
     return;
   }
 

--- a/backend/src/routes/image-metadata.ts
+++ b/backend/src/routes/image-metadata.ts
@@ -9,6 +9,7 @@ import { csrfProtection } from '../security.js';
 import { requireManager } from '../auth/middleware.js';
 import { generateStaticJSONFiles } from './static-json.js';
 import { invalidateAlbumCache } from './albums.js';
+import { getAlbumAccess, getValidShareLinkAlbum, isRequestAuthenticated } from '../utils/album-access.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const require = createRequire(import.meta.url);
@@ -27,24 +28,41 @@ const router = express.Router();
 // Apply CSRF protection to all routes
 router.use(csrfProtection);
 
+function sendAlbumAccessDenied(res: express.Response, access: { exists: boolean }): void {
+  if (!access.exists) {
+    res.status(404).json({ error: 'Album not found' });
+    return;
+  }
+
+  res.status(403).json({ error: 'Access denied' });
+}
+
 /**
- * GET /api/image-metadata/:album/:filename
- * Get metadata for a specific image
+ * GET /api/image-metadata/all
+ * Get all image metadata
  */
-router.get('/:album/:filename', async (req, res) => {
+router.get('/all', async (req, res) => {
   try {
-    const { album, filename } = req.params;
     const db = await getDbFunctions();
-    const metadata = db.getImageMetadata(album, filename);
-    
-    if (!metadata) {
-      res.status(404).json({ error: 'Metadata not found' });
+    const metadata = db.getAllMetadata();
+
+    if (isRequestAuthenticated(req)) {
+      res.json(metadata);
       return;
     }
-    
-    res.json(metadata);
+
+    const accessibleAlbums = new Set<string>(
+      db.getPublishedAlbums().map((album: { name: string }) => album.name)
+    );
+    const shareLinkAlbum = getValidShareLinkAlbum(req);
+
+    if (shareLinkAlbum) {
+      accessibleAlbums.add(shareLinkAlbum);
+    }
+
+    res.json(metadata.filter((item: { album: string }) => accessibleAlbums.has(item.album)));
   } catch (err) {
-    error('[ImageMetadata] Failed to fetch image metadata:', err);
+    error('[ImageMetadata] Failed to fetch all metadata:', err);
     res.status(500).json({ error: 'Failed to fetch metadata' });
   }
 });
@@ -56,6 +74,13 @@ router.get('/:album/:filename', async (req, res) => {
 router.get('/album/:album', async (req, res) => {
   try {
     const { album } = req.params;
+    const access = getAlbumAccess(req, album);
+
+    if (!access.allowed) {
+      sendAlbumAccessDenied(res, access);
+      return;
+    }
+
     const db = await getDbFunctions();
     const metadata = db.getAlbumMetadata(album);
     res.json(metadata);
@@ -66,16 +91,30 @@ router.get('/album/:album', async (req, res) => {
 });
 
 /**
- * GET /api/image-metadata/all
- * Get all image metadata
+ * GET /api/image-metadata/:album/:filename
+ * Get metadata for a specific image
  */
-router.get('/all', async (req, res) => {
+router.get('/:album/:filename', async (req, res) => {
   try {
+    const { album, filename } = req.params;
+    const access = getAlbumAccess(req, album);
+
+    if (!access.allowed) {
+      sendAlbumAccessDenied(res, access);
+      return;
+    }
+
     const db = await getDbFunctions();
-    const metadata = db.getAllMetadata();
+    const metadata = db.getImageMetadata(album, filename);
+
+    if (!metadata) {
+      res.status(404).json({ error: 'Metadata not found' });
+      return;
+    }
+
     res.json(metadata);
   } catch (err) {
-    error('[ImageMetadata] Failed to fetch all metadata:', err);
+    error('[ImageMetadata] Failed to fetch image metadata:', err);
     res.status(500).json({ error: 'Failed to fetch metadata' });
   }
 });
@@ -180,4 +219,3 @@ router.delete('/:album/:filename', requireManager, async (req, res) => {
 });
 
 export default router;
-

--- a/backend/src/routes/preview-grid.ts
+++ b/backend/src/routes/preview-grid.ts
@@ -9,9 +9,30 @@ import fs from "fs";
 import path from "path";
 import { getShareLinkBySecret, isShareLinkExpired, getImagesForHomepage } from "../database.js";
 import { DATA_DIR } from "../config.js";
+import { getAlbumAccess } from '../utils/album-access.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const router = Router();
+
+function resolveAlbumPath(photosDir: string, albumName: string): string | null {
+  const root = path.resolve(photosDir);
+  const candidate = path.resolve(root, albumName);
+
+  if (candidate === root || !candidate.startsWith(root + path.sep)) {
+    return null;
+  }
+
+  return candidate;
+}
+
+function sendAlbumAccessDenied(res: Response, access: { exists: boolean }): void {
+  if (!access.exists) {
+    res.status(404).json({ error: "Album not found" });
+    return;
+  }
+
+  res.status(403).json({ error: "Access denied" });
+}
 
 /**
  * Create a circular avatar with white border
@@ -233,8 +254,19 @@ router.get("/album/:albumName", async (req: Request, res: Response): Promise<voi
   try {
     const { albumName } = req.params;
     const photosDir = req.app.get("photosDir");
-    
-    const albumPath = path.join(photosDir, albumName);
+    const albumPath = resolveAlbumPath(photosDir, albumName);
+
+    if (!albumPath) {
+      res.status(400).json({ error: "Invalid album name" });
+      return;
+    }
+
+    const access = getAlbumAccess(req, albumName);
+
+    if (!access.allowed) {
+      sendAlbumAccessDenied(res, access);
+      return;
+    }
     
     if (!fs.existsSync(albumPath) || !fs.statSync(albumPath).isDirectory()) {
       res.status(404).json({ error: "Album not found" });
@@ -402,7 +434,12 @@ router.get("/shared/:secretKey", async (req: Request, res: Response): Promise<vo
     
     const albumName = shareLink.album;
     const photosDir = req.app.get("photosDir");
-    const albumPath = path.join(photosDir, albumName);
+    const albumPath = resolveAlbumPath(photosDir, albumName);
+
+    if (!albumPath) {
+      res.status(404).json({ error: "Album not found" });
+      return;
+    }
     
     if (!fs.existsSync(albumPath) || !fs.statSync(albumPath).isDirectory()) {
       res.status(404).json({ error: "Album not found" });

--- a/backend/src/routes/share-links.ts
+++ b/backend/src/routes/share-links.ts
@@ -5,7 +5,7 @@
 
 import { Router, Request, Response } from "express";
 import { csrfProtection } from "../security.js";
-import { requireAuth, requireManager } from '../auth/middleware.js';
+import { requireManager } from '../auth/middleware.js';
 import { 
   createShareLink, 
   getShareLinkBySecret, 
@@ -181,7 +181,7 @@ router.get("/validate/:secretKey", async (req: Request, res: Response): Promise<
  * Get all share links for an album (admin only)
  * GET /api/share-links/album/:album
  */
-router.get("/album/:album", requireAuth, async (req: Request, res: Response): Promise<void> => {
+router.get("/album/:album", requireManager, async (req: Request, res: Response): Promise<void> => {
   try {
     const { album } = req.params;
     

--- a/backend/src/routes/static-json.ts
+++ b/backend/src/routes/static-json.ts
@@ -74,13 +74,12 @@ export async function generateStaticJSONFiles(appRoot: string): Promise<{ succes
     const outputDir = getOutputDir(appRoot);
     ensureOutputDir(outputDir);
 
-    // Get ALL albums (published + unpublished) - admins need fast access to unpublished albums too
     const albumsData = getAllAlbums();
-    const albums = albumsData
-      .filter(a => a.name !== 'homepage')
+    const publicAlbumsData = albumsData.filter(a => a.name !== 'homepage' && a.published);
+    const albums = publicAlbumsData
       .map(a => a.name);
 
-    // Clean up stale JSON files for DELETED albums only (keep unpublished albums)
+    // Clean up stale JSON files for deleted or unpublished albums.
     if (fs.existsSync(outputDir)) {
       const existingFiles = fs.readdirSync(outputDir);
       const albumJsonFiles = existingFiles.filter(f => f.endsWith('.json') && f !== 'homepage.json' && f !== 'albums-list.json' && f !== '_metadata.json');
@@ -88,7 +87,6 @@ export async function generateStaticJSONFiles(appRoot: string): Promise<{ succes
       for (const file of albumJsonFiles) {
         const albumName = file.replace('.json', '');
         if (!albums.includes(albumName)) {
-          // This JSON file corresponds to a DELETED album (not just unpublished)
           const filePath = path.join(outputDir, file);
           fs.unlinkSync(filePath);
         }
@@ -99,7 +97,7 @@ export async function generateStaticJSONFiles(appRoot: string): Promise<{ succes
     await Promise.all(
       albums.map(async (album) => {
         try {
-          const albumState = albumsData.find(a => a.name === album);
+          const albumState = publicAlbumsData.find(a => a.name === album);
           const images = getImagesInAlbum(album);
           const photos = images.map((img) =>
             transformImageToArray(img, album, false, albumState?.downloads_enabled ?? true)

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -45,6 +45,7 @@ import {
   verbose,
   trace,
 } from "./utils/logger.ts";
+import { getAlbumAccess, isRequestAuthenticated } from "./utils/album-access.ts";
 
 // Initialize logger early with config or environment variable
 initLogger(getLogLevel());
@@ -667,42 +668,31 @@ const checkAlbumPublishedMiddleware = (
   const pathParts = req.path.split('/').filter(p => p);
   
   if (pathParts.length >= 2) {
-    const album = decodeURIComponent(pathParts[1]); // Second part is the album name (URL decode it!)
-    
-    // Check if user is authenticated
-    const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
-    
-    // Check for share link in query parameter
-    // Note: req.query.key can be a string OR an array if multiple keys are provided
-    const shareKeyParam = req.query.key;
-    const shareKey = Array.isArray(shareKeyParam) ? shareKeyParam[0] : shareKeyParam;
-    let hasValidShareLink = false;
-    
-    if (shareKey && typeof shareKey === 'string' && /^[a-f0-9]{64}$/i.test(shareKey)) {
-      const { getShareLinkBySecret, isShareLinkExpired } = require('./database.js');
-      const shareLink = getShareLinkBySecret(shareKey);
-      if (shareLink && shareLink.album === album && !isShareLinkExpired(shareLink)) {
-        hasValidShareLink = true;
-      }
+    let album: string;
+
+    try {
+      album = decodeURIComponent(pathParts[1]); // Second part is the album name (URL decode it!)
+    } catch {
+      res.status(400).json({ error: "Invalid image path" });
+      return;
     }
-    
-    // Check album published state
-    const { getAlbumState } = require('./database.js');
-    const albumState = getAlbumState(album);
+
+    const access = getAlbumAccess(req, album);
     
     // Return 404 if album doesn't exist at all
-    if (!albumState) {
+    if (!access.exists) {
       res.status(404).json({ error: "Image not found" });
       return;
     }
     
-    // Deny access if album is unpublished and user is not authenticated and no valid share link
-    if (!albumState.published && !isAuthenticated && !hasValidShareLink) {
+    if (!access.allowed) {
       res.status(403).json({ error: "Access denied" });
       return;
     }
 
-    if (pathParts[0] === "download" && !albumState.downloads_enabled && !isAuthenticated) {
+    const albumState = access.albumState!;
+
+    if (pathParts[0] === "download" && !albumState.downloads_enabled && !isRequestAuthenticated(req)) {
       res.status(403).json({ error: "Downloads disabled" });
       return;
     }

--- a/backend/src/utils/album-access.test.ts
+++ b/backend/src/utils/album-access.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import type { Request } from 'express';
+
+const dataDir = mkdtempSync(path.join(tmpdir(), 'galleria-album-access-'));
+process.env.DATA_DIR = dataDir;
+
+let albumAccess: typeof import('./album-access.js');
+let shareKey = '';
+let expiredShareKey = '';
+
+function request(options: { authenticated?: boolean; key?: string } = {}): Request {
+  return {
+    isAuthenticated: () => Boolean(options.authenticated),
+    session: options.authenticated ? { userId: 1 } : {},
+    query: options.key ? { key: options.key } : {},
+  } as unknown as Request;
+}
+
+test.after(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+test.before(async () => {
+  const database = await import('../database.js');
+  albumAccess = await import('./album-access.js');
+
+  database.initializeDatabase();
+  database.saveAlbum('Published', true);
+  database.saveAlbum('Private', false);
+  database.saveAlbum('OtherPrivate', false);
+  shareKey = database.createShareLink('Private', null).secret_key;
+  expiredShareKey = database.createShareLink('Private', new Date(Date.now() - 60_000).toISOString()).secret_key;
+});
+
+test('allows public access to published albums', () => {
+  const access = albumAccess.getAlbumAccess(request(), 'Published');
+
+  assert.equal(access.allowed, true);
+  assert.equal(access.reason, 'published');
+});
+
+test('denies anonymous access to unpublished albums without a valid share link', () => {
+  const access = albumAccess.getAlbumAccess(request(), 'Private');
+
+  assert.equal(access.allowed, false);
+  assert.equal(access.exists, true);
+  assert.equal(access.reason, 'denied');
+});
+
+test('allows authenticated access to unpublished albums', () => {
+  const access = albumAccess.getAlbumAccess(request({ authenticated: true }), 'Private');
+
+  assert.equal(access.allowed, true);
+  assert.equal(access.reason, 'authenticated');
+});
+
+test('allows share-link access only for the matching unexpired album', () => {
+  const allowed = albumAccess.getAlbumAccess(request({ key: shareKey }), 'Private');
+  const wrongAlbum = albumAccess.getAlbumAccess(request({ key: shareKey }), 'OtherPrivate');
+  const expired = albumAccess.getAlbumAccess(request({ key: expiredShareKey }), 'Private');
+
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.reason, 'share_link');
+  assert.equal(wrongAlbum.allowed, false);
+  assert.equal(wrongAlbum.reason, 'denied');
+  assert.equal(expired.allowed, false);
+  assert.equal(expired.reason, 'denied');
+});

--- a/backend/src/utils/album-access.test.ts
+++ b/backend/src/utils/album-access.test.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import type { Request } from 'express';
+import express, { type Express, type Request, type Router } from 'express';
 
 const dataDir = mkdtempSync(path.join(tmpdir(), 'galleria-album-access-'));
+const appRoot = path.join(dataDir, 'app-root');
+const photosDir = path.join(dataDir, 'photos');
 process.env.DATA_DIR = dataDir;
 
 interface AccessResult {
@@ -24,6 +28,10 @@ interface RequestOptions {
 }
 
 let albumAccess: AlbumAccessModule;
+let imageMetadataRouter: Router;
+let previewGridRouter: Router;
+let albumsRouter: Router;
+let generateStaticJSONFiles: (appRoot: string) => Promise<{ success: boolean; error?: string; albumCount?: number }>;
 let shareKey = '';
 let expiredShareKey = '';
 
@@ -35,18 +43,105 @@ function request(options: RequestOptions = {}): Request {
   } as unknown as Request;
 }
 
+function createRouteApp(): Express {
+  const app = express();
+
+  app.set('photosDir', photosDir);
+  app.set('appRoot', appRoot);
+  app.use((req, _res, next) => {
+    const authenticated = req.get('x-test-auth') === '1';
+    (req as any).isAuthenticated = () => authenticated;
+    (req as any).session = authenticated ? { userId: 1 } : {};
+    next();
+  });
+  app.use('/api/image-metadata', imageMetadataRouter);
+  app.use('/api/preview-grid', previewGridRouter);
+  app.use(albumsRouter);
+
+  return app;
+}
+
+async function withRouteApp(assertions: (baseUrl: string) => Promise<void>): Promise<void> {
+  const app = createRouteApp();
+  const server = app.listen(0);
+
+  await once(server, 'listening');
+
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+
+  try {
+    await assertions(`http://127.0.0.1:${(address as AddressInfo).port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+async function fetchRoute(baseUrl: string, pathname: string, options: { authenticated?: boolean } = {}): Promise<Response> {
+  const headers: Record<string, string> = {};
+
+  if (options.authenticated) {
+    headers['x-test-auth'] = '1';
+  }
+
+  return fetch(`${baseUrl}${pathname}`, { headers });
+}
+
 test.after(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
 test.before(async () => {
+  mkdirSync(path.join(photosDir, 'Published'), { recursive: true });
+  mkdirSync(path.join(photosDir, 'Private'), { recursive: true });
+  mkdirSync(appRoot, { recursive: true });
+  writeFileSync(path.join(dataDir, 'config.json'), JSON.stringify({
+    environment: {
+      frontend: { port: 3000, apiUrl: 'http://localhost:3000' },
+      backend: { port: 3001, allowedOrigins: ['http://localhost:3000'] },
+      security: { allowedHosts: ['localhost:3000'], rateLimitWindowMs: 1000, rateLimitMaxRequests: 100 },
+      logging: { level: 'error' },
+      auth: {
+        google: { enabled: false, clientId: '', clientSecret: '' },
+        sessionSecret: 'test-session-secret',
+        authorizedEmails: [],
+      },
+    },
+    branding: { avatarPath: '/photos/avatar.png' },
+    analytics: { enabled: false, openobserve: {} },
+    externalLinks: [],
+  }));
+
+  const sharp = (await import('sharp')).default;
+  await Promise.all([
+    sharp({ create: { width: 4, height: 4, channels: 3, background: '#ffffff' } }).jpeg().toFile(path.join(photosDir, 'Published', 'published.jpg')),
+    sharp({ create: { width: 4, height: 4, channels: 3, background: '#111111' } }).jpeg().toFile(path.join(photosDir, 'Private', 'private.jpg')),
+  ]);
+
   const database = await import('../database.js');
   albumAccess = await import('./album-access.js');
+  imageMetadataRouter = (await import('../routes/image-metadata.js')).default;
+  previewGridRouter = (await import('../routes/preview-grid.js')).default;
+  albumsRouter = (await import('../routes/albums.js')).default;
+  ({ generateStaticJSONFiles } = await import('../routes/static-json.js'));
 
   database.initializeDatabase();
   database.saveAlbum('Published', true);
   database.saveAlbum('Private', false);
   database.saveAlbum('OtherPrivate', false);
+  database.saveImageMetadata('Published', 'published.jpg', 'Published Photo', 'Public description');
+  database.saveImageMetadata('Published', 'published-video.mp4', 'Published Video', 'Public video', 'video');
+  database.saveImageMetadata('Private', 'private.jpg', 'Private Photo', 'Secret description');
+  database.saveImageMetadata('Private', 'private-video.mp4', 'Private Video', 'Secret video', 'video');
+  database.saveImageMetadata('OtherPrivate', 'other.jpg', 'Other Private Photo', null);
   shareKey = database.createShareLink('Private', null).secret_key;
   expiredShareKey = database.createShareLink('Private', new Date(Date.now() - 60_000).toISOString()).secret_key;
 });
@@ -84,4 +179,87 @@ test('allows share-link access only for the matching unexpired album', () => {
   assert.equal(wrongAlbum.reason, 'denied');
   assert.equal(expired.allowed, false);
   assert.equal(expired.reason, 'denied');
+});
+
+test('image metadata routes filter or deny unpublished albums unless authenticated or shared', async () => {
+  await withRouteApp(async (baseUrl) => {
+    const allResponse = await fetchRoute(baseUrl, '/api/image-metadata/all');
+    assert.equal(allResponse.status, 200);
+    const allMetadata = await allResponse.json() as Array<{ album: string; filename: string }>;
+    assert.deepEqual(new Set(allMetadata.map(item => item.album)), new Set(['Published']));
+
+    const sharedAllResponse = await fetchRoute(baseUrl, `/api/image-metadata/all?key=${shareKey}`);
+    assert.equal(sharedAllResponse.status, 200);
+    const sharedAllMetadata = await sharedAllResponse.json() as Array<{ album: string }>;
+    assert.deepEqual(new Set(sharedAllMetadata.map(item => item.album)), new Set(['Private', 'Published']));
+
+    const privateAlbumResponse = await fetchRoute(baseUrl, '/api/image-metadata/album/Private');
+    assert.equal(privateAlbumResponse.status, 403);
+
+    const sharedAlbumResponse = await fetchRoute(baseUrl, `/api/image-metadata/album/Private?key=${shareKey}`);
+    assert.equal(sharedAlbumResponse.status, 200);
+    const sharedAlbumMetadata = await sharedAlbumResponse.json() as Array<{ filename: string }>;
+    assert.deepEqual(new Set(sharedAlbumMetadata.map(item => item.filename)), new Set(['private.jpg', 'private-video.mp4']));
+
+    const privateImageResponse = await fetchRoute(baseUrl, '/api/image-metadata/Private/private.jpg');
+    assert.equal(privateImageResponse.status, 403);
+
+    const authenticatedImageResponse = await fetchRoute(baseUrl, '/api/image-metadata/Private/private.jpg', { authenticated: true });
+    assert.equal(authenticatedImageResponse.status, 200);
+
+    const sharedImageResponse = await fetchRoute(baseUrl, `/api/image-metadata/Private/private.jpg?key=${shareKey}`);
+    assert.equal(sharedImageResponse.status, 200);
+    const sharedImageMetadata = await sharedImageResponse.json() as { title: string };
+    assert.equal(sharedImageMetadata.title, 'Private Photo');
+  });
+});
+
+test('preview grid route denies unpublished albums anonymously and allows valid share links', async () => {
+  await withRouteApp(async (baseUrl) => {
+    const anonymousPrivateResponse = await fetchRoute(baseUrl, '/api/preview-grid/album/Private');
+    assert.equal(anonymousPrivateResponse.status, 403);
+
+    const publishedResponse = await fetchRoute(baseUrl, '/api/preview-grid/album/Published');
+    assert.equal(publishedResponse.status, 200);
+    assert.match(publishedResponse.headers.get('content-type') ?? '', /^image\/jpeg/);
+
+    const sharedPrivateResponse = await fetchRoute(baseUrl, `/api/preview-grid/album/Private?key=${shareKey}`);
+    assert.equal(sharedPrivateResponse.status, 200);
+    assert.match(sharedPrivateResponse.headers.get('content-type') ?? '', /^image\/jpeg/);
+  });
+});
+
+test('EXIF and video metadata routes check album access before file existence', async () => {
+  await withRouteApp(async (baseUrl) => {
+    const privateExifResponse = await fetchRoute(baseUrl, '/api/photos/Private/missing.jpg/exif');
+    assert.equal(privateExifResponse.status, 403);
+
+    const publishedExifResponse = await fetchRoute(baseUrl, '/api/photos/Published/missing.jpg/exif');
+    assert.equal(publishedExifResponse.status, 404);
+
+    const sharedExifResponse = await fetchRoute(baseUrl, `/api/photos/Private/private.jpg/exif?key=${shareKey}`);
+    assert.equal(sharedExifResponse.status, 200);
+
+    const privateVideoResponse = await fetchRoute(baseUrl, '/api/videos/Private/missing.mp4/metadata');
+    assert.equal(privateVideoResponse.status, 403);
+
+    const authenticatedVideoResponse = await fetchRoute(baseUrl, '/api/videos/Private/missing.mp4/metadata', { authenticated: true });
+    assert.equal(authenticatedVideoResponse.status, 404);
+  });
+});
+
+test('static JSON generation removes stale unpublished album files', async () => {
+  const outputDir = path.join(appRoot, 'frontend', 'dist', 'albums-data');
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(path.join(outputDir, 'Private.json'), JSON.stringify([['private.jpg', 'Private Photo']]));
+
+  const result = await generateStaticJSONFiles(appRoot);
+
+  assert.equal(result.success, true);
+  assert.equal(result.albumCount, 1);
+  assert.equal(existsSync(path.join(outputDir, 'Private.json')), false);
+  assert.equal(existsSync(path.join(outputDir, 'Published.json')), true);
+
+  const albumsList = JSON.parse(readFileSync(path.join(outputDir, 'albums-list.json'), 'utf8'));
+  assert.deepEqual(albumsList, ['Published']);
 });

--- a/backend/src/utils/album-access.test.ts
+++ b/backend/src/utils/album-access.test.ts
@@ -8,11 +8,26 @@ import type { Request } from 'express';
 const dataDir = mkdtempSync(path.join(tmpdir(), 'galleria-album-access-'));
 process.env.DATA_DIR = dataDir;
 
-let albumAccess: typeof import('./album-access.js');
+interface AccessResult {
+  allowed: boolean;
+  exists: boolean;
+  reason: string;
+}
+
+interface AlbumAccessModule {
+  getAlbumAccess(req: Request, albumName: string): AccessResult;
+}
+
+interface RequestOptions {
+  authenticated?: boolean;
+  key?: string;
+}
+
+let albumAccess: AlbumAccessModule;
 let shareKey = '';
 let expiredShareKey = '';
 
-function request(options: { authenticated?: boolean; key?: string } = {}): Request {
+function request(options: RequestOptions = {}): Request {
   return {
     isAuthenticated: () => Boolean(options.authenticated),
     session: options.authenticated ? { userId: 1 } : {},

--- a/backend/src/utils/album-access.ts
+++ b/backend/src/utils/album-access.ts
@@ -1,0 +1,96 @@
+import type { Request } from 'express';
+import { getAlbumState, getShareLinkBySecret, isShareLinkExpired } from '../database.js';
+
+type AlbumState = NonNullable<ReturnType<typeof getAlbumState>>;
+
+export interface AlbumAccessResult {
+  allowed: boolean;
+  exists: boolean;
+  albumState?: AlbumState;
+  reason: 'not_found' | 'published' | 'authenticated' | 'share_link' | 'denied';
+}
+
+export function isRequestAuthenticated(req: Request): boolean {
+  return Boolean((req.isAuthenticated && req.isAuthenticated()) || (req.session as any)?.userId);
+}
+
+export function getShareKeyFromRequest(req: Request): string | null {
+  const shareKeyParam = req.query.key;
+  const shareKey = Array.isArray(shareKeyParam) ? shareKeyParam[0] : shareKeyParam;
+
+  if (typeof shareKey !== 'string' || !/^[a-f0-9]{64}$/i.test(shareKey)) {
+    return null;
+  }
+
+  return shareKey;
+}
+
+export function getValidShareLinkAlbum(req: Request): string | null {
+  const shareKey = getShareKeyFromRequest(req);
+
+  if (!shareKey) {
+    return null;
+  }
+
+  const shareLink = getShareLinkBySecret(shareKey);
+
+  if (!shareLink || isShareLinkExpired(shareLink)) {
+    return null;
+  }
+
+  return shareLink.album;
+}
+
+export function hasValidShareLinkForAlbum(req: Request, albumName: string): boolean {
+  return getValidShareLinkAlbum(req) === albumName;
+}
+
+export function getAlbumAccess(req: Request, albumName: string): AlbumAccessResult {
+  const albumState = getAlbumState(albumName);
+
+  if (!albumState) {
+    return {
+      allowed: false,
+      exists: false,
+      reason: 'not_found',
+    };
+  }
+
+  if (albumState.published) {
+    return {
+      allowed: true,
+      exists: true,
+      albumState,
+      reason: 'published',
+    };
+  }
+
+  if (isRequestAuthenticated(req)) {
+    return {
+      allowed: true,
+      exists: true,
+      albumState,
+      reason: 'authenticated',
+    };
+  }
+
+  if (hasValidShareLinkForAlbum(req, albumName)) {
+    return {
+      allowed: true,
+      exists: true,
+      albumState,
+      reason: 'share_link',
+    };
+  }
+
+  return {
+    allowed: false,
+    exists: true,
+    albumState,
+    reason: 'denied',
+  };
+}
+
+export function canAccessAlbum(req: Request, albumName: string): boolean {
+  return getAlbumAccess(req, albumName).allowed;
+}

--- a/frontend/src/components/ContentModal/ContentModal.tsx
+++ b/frontend/src/components/ContentModal/ContentModal.tsx
@@ -648,6 +648,7 @@ const ContentModal: React.FC<ContentModalProps> = ({
               exifData={exifData}
               loadingExif={loadingExif}
               imageTitle={selectedPhoto.title}
+              secretKey={secretKey}
               style={{}}
             />
 

--- a/frontend/src/components/ContentModal/ContentModal.tsx
+++ b/frontend/src/components/ContentModal/ContentModal.tsx
@@ -71,13 +71,6 @@ const ContentModal: React.FC<ContentModalProps> = ({
   // For image URLs, don't include query strings to improve caching (especially on iOS)
   const imageQueryString = ``;
   
-  // Get query parameters for API calls
-  const queryParams = new URLSearchParams(window.location.search);
-  queryParams.delete('photo');
-  const queryString = queryParams.toString()
-    ? `?${queryParams.toString()}&i=${cacheBustValue}`
-    : `?i=${cacheBustValue}`;
-
   // Update URL with photo parameter
   const updateURLWithPhoto = useCallback((photo: Photo) => {
     const filename = photo.id.split('/').pop();
@@ -323,8 +316,15 @@ const ContentModal: React.FC<ContentModalProps> = ({
     setLoadingExif(true);
     try {
       const filename = photo.id.split('/').pop();
+      const exifQueryParams = new URLSearchParams(window.location.search);
+      exifQueryParams.delete('photo');
+      if (secretKey) {
+        exifQueryParams.set('key', secretKey);
+      }
+      exifQueryParams.set('i', String(cacheBustValue));
+      const exifQueryString = exifQueryParams.toString();
       const res = await fetchWithRateLimitCheck(
-        `${API_URL}/api/photos/${photo.album}/${filename}/exif${queryString ? '?' + queryString : ''}`
+        `${API_URL}/api/photos/${photo.album}/${filename}/exif${exifQueryString ? `?${exifQueryString}` : ''}`
       );
       
       if (res.ok) {
@@ -340,7 +340,7 @@ const ContentModal: React.FC<ContentModalProps> = ({
     } finally {
       setLoadingExif(false);
     }
-  }, [exifData, queryString]);
+  }, [exifData, secretKey]);
 
   // Toggle info panel
   const handleToggleInfo = useCallback(() => {

--- a/frontend/src/components/ContentModal/InfoPanel.tsx
+++ b/frontend/src/components/ContentModal/InfoPanel.tsx
@@ -23,6 +23,7 @@ interface InfoPanelProps {
   exifData: ExifData | null;
   loadingExif: boolean;
   imageTitle?: string | null;
+  secretKey?: string;
   style?: React.CSSProperties;
 }
 
@@ -34,6 +35,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
   exifData,
   loadingExif,
   imageTitle,
+  secretKey,
   style,
 }) => {
   const { t, i18n } = useTranslation();
@@ -48,7 +50,8 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
         setLoadingVideo(true);
         try {
           const filename = photo.id.split('/').pop();
-          const res = await fetch(`${API_URL}/api/videos/${photo.album}/${filename}/metadata`, {
+          const queryString = secretKey ? `?key=${encodeURIComponent(secretKey)}` : '';
+          const res = await fetch(`${API_URL}/api/videos/${photo.album}/${filename}/metadata${queryString}`, {
             credentials: 'include'
           });
           
@@ -65,7 +68,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
       
       fetchVideoMetadata();
     }
-  }, [show, isVideo, photo.album, photo.id]);
+  }, [show, isVideo, photo.album, photo.id, secretKey]);
   
   // Format duration from seconds to MM:SS or HH:MM:SS
   const formatDuration = (seconds: number): string => {
@@ -214,4 +217,3 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
 };
 
 export default InfoPanel;
-

--- a/scripts/generate-static-json.js
+++ b/scripts/generate-static-json.js
@@ -64,10 +64,33 @@ try {
     ];
   }
 
-  // Get all albums (including unpublished)
+  // Get only published albums for public static JSON.
   console.log('\n📁 Fetching albums...');
-  const albums = db.prepare(`SELECT name, ${downloadsEnabledSelect} FROM albums ORDER BY sort_order, name`).all();
-  console.log(`   Found ${albums.length} albums (including unpublished)`);
+  const albums = db.prepare(`
+    SELECT name, ${downloadsEnabledSelect}
+    FROM albums
+    WHERE published = 1
+    ORDER BY sort_order, name
+  `).all();
+  const albumNames = albums.map(a => a.name);
+  console.log(`   Found ${albums.length} published albums`);
+
+  const existingFiles = fs.readdirSync(OUTPUT_DIR);
+  const albumJsonFiles = existingFiles.filter(file =>
+    file.endsWith('.json') &&
+    file !== 'homepage.json' &&
+    file !== 'albums-list.json' &&
+    file !== '_metadata.json'
+  );
+
+  for (const file of albumJsonFiles) {
+    const albumName = file.slice(0, -'.json'.length);
+
+    if (!albumNames.includes(albumName)) {
+      fs.unlinkSync(path.join(OUTPUT_DIR, file));
+      console.log(`   🧹 Removed stale public JSON: ${file}`);
+    }
+  }
 
   // Generate JSON for each album
   console.log('\n📸 Generating album JSON files...');
@@ -138,7 +161,6 @@ try {
 
   // Generate albums list
   console.log('\n📋 Generating albums list...');
-  const albumNames = albums.map(a => a.name);
   writeJSON('albums-list.json', albumNames);
 
   // Generate metadata file


### PR DESCRIPTION
Protects public read paths for album metadata, preview grids, EXIF/video metadata, and optimized assets behind a shared published/authenticated/share-link access check. Static albums-data generation now publishes only published albums and removes stale unpublished JSON files. Also tightens share-link secret listing to manager/admin users and adds focused access-policy regression coverage.