### PR TITLE
fix: allow share expiry dropdown to scroll (ticket #1600)

### DIFF
--- a/frontend/src/components/AdminPortal/ConfigManager/components/CustomDropdown.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/components/CustomDropdown.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface DropdownOption {
   value: string;
@@ -14,6 +15,14 @@ interface CustomDropdownProps {
   placeholder?: string;
   style?: React.CSSProperties;
   openUpward?: boolean;
+  portal?: boolean;
+}
+
+interface PortalMenuPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
 }
 
 export default function CustomDropdown({
@@ -24,17 +33,48 @@ export default function CustomDropdown({
   placeholder = 'Select...',
   style = {},
   openUpward = false,
+  portal = false,
 }: CustomDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [portalMenuPosition, setPortalMenuPosition] = useState<PortalMenuPosition | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const selectedOption = options.find((opt) => opt.value === value);
 
+  const updatePortalMenuPosition = useCallback(() => {
+    if (!dropdownRef.current) {
+      return;
+    }
+
+    const triggerRect = dropdownRef.current.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
+    const gap = 4;
+    const spaceAbove = triggerRect.top - gap;
+    const spaceBelow = viewportHeight - triggerRect.bottom - gap;
+    const shouldOpenUpward = openUpward || (spaceBelow < 260 && spaceAbove > spaceBelow);
+    const availableSpace = Math.max(shouldOpenUpward ? spaceAbove : spaceBelow, 120);
+    const maxHeight = Math.min(300, availableSpace);
+
+    setPortalMenuPosition({
+      top: shouldOpenUpward
+        ? Math.max(gap, triggerRect.top - maxHeight - gap)
+        : Math.max(gap, Math.min(triggerRect.bottom + gap, viewportHeight - maxHeight - gap)),
+      left: Math.max(gap, Math.min(triggerRect.left, viewportWidth - triggerRect.width - gap)),
+      width: Math.min(triggerRect.width, viewportWidth - gap * 2),
+      maxHeight,
+    });
+  }, [openUpward]);
+
   // Close dropdown when clicking outside or scrolling (but not when scrolling inside the dropdown)
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        (!menuRef.current || !menuRef.current.contains(event.target as Node))
+      ) {
         setIsOpen(false);
       }
     };
@@ -71,10 +111,96 @@ export default function CustomDropdown({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen || !portal) {
+      return;
+    }
+
+    updatePortalMenuPosition();
+    window.addEventListener('resize', updatePortalMenuPosition);
+
+    return () => {
+      window.removeEventListener('resize', updatePortalMenuPosition);
+    };
+  }, [isOpen, portal, updatePortalMenuPosition]);
+
   const handleSelect = (optionValue: string) => {
     onChange(optionValue);
     setIsOpen(false);
   };
+
+  const handleToggle = () => {
+    if (disabled) {
+      return;
+    }
+
+    if (!isOpen && portal) {
+      updatePortalMenuPosition();
+    }
+
+    setIsOpen((current) => !current);
+  };
+
+  const menuPositionStyle: React.CSSProperties = portal
+    ? {
+        position: 'fixed',
+        top: portalMenuPosition?.top ?? 0,
+        left: portalMenuPosition?.left ?? 0,
+        width: portalMenuPosition?.width ?? '100%',
+        maxHeight: portalMenuPosition?.maxHeight ?? 300,
+      }
+    : {
+        position: 'absolute',
+        ...(openUpward ? { bottom: '100%', marginBottom: '4px' } : { top: '100%', marginTop: '4px' }),
+        left: 0,
+        right: 0,
+        maxHeight: '300px',
+      };
+
+  const dropdownMenu = isOpen && !disabled ? (
+    <div
+      ref={menuRef}
+      style={{
+        ...menuPositionStyle,
+        background: '#1a1a1a',
+        border: '1px solid #3a3a3a',
+        borderRadius: '8px',
+        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.5)',
+        zIndex: portal ? 10001 : 999999,
+        overflowY: 'auto',
+        overscrollBehavior: 'contain', // Prevent scroll chaining to parent
+      }}
+    >
+      {options.map((option) => (
+        <div
+          key={option.value}
+          onClick={() => handleSelect(option.value)}
+          style={{
+            padding: '0.65rem 0.75rem',
+            cursor: 'pointer',
+            color: value === option.value ? '#4ade80' : '#e5e7eb',
+            background: value === option.value ? 'rgba(74, 222, 128, 0.1)' : 'transparent',
+            transition: 'background 0.2s',
+            fontSize: '0.9rem',
+          }}
+          onMouseEnter={(e) => {
+            if (value !== option.value) {
+              e.currentTarget.style.background = 'rgba(255, 255, 255, 0.05)';
+            }
+          }}
+          onMouseLeave={(e) => {
+            if (value !== option.value) {
+              e.currentTarget.style.background = 'transparent';
+            }
+          }}
+        >
+          {option.emoji && `${option.emoji} `}
+          {option.label}
+          {value === option.value && ' ✓'}
+        </div>
+      ))}
+    </div>
+  ) : null;
 
   return (
     <div
@@ -87,7 +213,7 @@ export default function CustomDropdown({
     >
       {/* Dropdown Button */}
       <div
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+        onClick={handleToggle}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -137,54 +263,9 @@ export default function CustomDropdown({
       </div>
 
       {/* Dropdown Menu */}
-      {isOpen && !disabled && (
-        <div
-          ref={menuRef}
-          style={{
-            position: 'absolute',
-            ...(openUpward ? { bottom: '100%', marginBottom: '4px' } : { top: '100%', marginTop: '4px' }),
-            left: 0,
-            right: 0,
-            background: '#1a1a1a',
-            border: '1px solid #3a3a3a',
-            borderRadius: '8px',
-            boxShadow: '0 8px 24px rgba(0, 0, 0, 0.5)',
-            zIndex: 999999,
-            maxHeight: '300px',
-            overflowY: 'auto',
-            overscrollBehavior: 'contain', // Prevent scroll chaining to parent
-          }}
-        >
-          {options.map((option) => (
-            <div
-              key={option.value}
-              onClick={() => handleSelect(option.value)}
-              style={{
-                padding: '0.65rem 0.75rem',
-                cursor: 'pointer',
-                color: value === option.value ? '#4ade80' : '#e5e7eb',
-                background: value === option.value ? 'rgba(74, 222, 128, 0.1)' : 'transparent',
-                transition: 'background 0.2s',
-                fontSize: '0.9rem',
-              }}
-              onMouseEnter={(e) => {
-                if (value !== option.value) {
-                  e.currentTarget.style.background = 'rgba(255, 255, 255, 0.05)';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (value !== option.value) {
-                  e.currentTarget.style.background = 'transparent';
-                }
-              }}
-            >
-              {option.emoji && `${option.emoji} `}
-              {option.label}
-              {value === option.value && ' ✓'}
-            </div>
-          ))}
-        </div>
-      )}
+      {portal && dropdownMenu && typeof document !== 'undefined'
+        ? createPortal(dropdownMenu, document.body)
+        : dropdownMenu}
     </div>
   );
 }

--- a/frontend/src/components/AdminPortal/ShareModal.tsx
+++ b/frontend/src/components/AdminPortal/ShareModal.tsx
@@ -147,6 +147,7 @@ export default function ShareModal({ album, onClose }: ShareModalProps) {
                 handleExpirationChange(newExpiration);
               }}
               disabled={loading}
+              portal
             />
           </div>
 

--- a/frontend/src/components/AdminPortal/VideoShareModal.tsx
+++ b/frontend/src/components/AdminPortal/VideoShareModal.tsx
@@ -154,6 +154,7 @@ export default function VideoShareModal({ album, filename, videoTitle, onClose }
                 handleExpirationChange(newExpiration);
               }}
               disabled={loading}
+              portal
             />
           </div>
 
@@ -187,6 +188,5 @@ export default function VideoShareModal({ album, filename, videoTitle, onClose }
     </div>
   );
 }
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galleria",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galleria",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "workspaces": [
         "frontend",
         "backend"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galleria",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Fixes ticket #1600 by rendering the share expiration dropdown in a viewport-positioned portal so it is not clipped by the scrollable modal. Also bumps the root app version from 1.1.3 to 1.1.4.