### PR TITLE
fix: reject getVideoMetadata on spawn failure and empty streams (ticket #2742)

### DIFF
--- a/backend/src/utils/video-processor.ts
+++ b/backend/src/utils/video-processor.ts
@@ -75,6 +75,11 @@ export async function getVideoMetadata(videoPath: string): Promise<VideoMetadata
       stderr += data.toString();
     });
 
+    // Reject on spawn failure (e.g. ffprobe missing / ENOENT) so callers do not hang
+    ffprobe.on('error', (err) => {
+      reject(new Error(`ffprobe spawn failed: ${err.message}`));
+    });
+
     ffprobe.on('close', (code) => {
       if (code !== 0) {
         reject(new Error(`ffprobe failed: ${stderr}`));
@@ -83,13 +88,17 @@ export async function getVideoMetadata(videoPath: string): Promise<VideoMetadata
 
       try {
         const data = JSON.parse(stdout);
-        const stream = data.streams[0];
+        const stream = data.streams?.[0];
+        if (!stream) {
+          reject(new Error('ffprobe returned no video stream'));
+          return;
+        }
         const format = data.format;
 
         resolve({
           width: stream.width || 1920,
           height: stream.height || 1080,
-          duration: parseFloat(stream.duration || format.duration || '0'),
+          duration: parseFloat(stream.duration || format?.duration || '0'),
           rotation: stream.rotation || 0
         });
       } catch (err) {


### PR DESCRIPTION
## Summary
`getVideoMetadata` only handled `close`/`data` on the ffprobe child. If ffprobe was missing (ENOENT) the Promise never settled, so video upload/processing hung. On success with empty `streams[]`, property access on `undefined` threw.

## Changes
- `ffprobe.on('error', …)` rejects the Promise (matches other spawn sites in this module)
- Guard `!data.streams?.[0]` before reading dimensions/duration/rotation

## Test plan
- [ ] Process/upload path with ffprobe absent rejects promptly (no hang)
- [ ] File with no video stream rejects with a clear error
- [ ] Normal video still returns width/height/duration/rotation