### PR TITLE
fix: prevent optimization timeout double-firing onError/processQueue (ticket #2745)

### DIFF
--- a/backend/src/routes/optimization-stream.ts
+++ b/backend/src/routes/optimization-stream.ts
@@ -109,13 +109,27 @@ async function processQueue() {
 
     activeJobs.add(childProcess);
 
-    // Add timeout to prevent hung processes (5 minutes)
-    const timeout = setTimeout(() => {
-      error(`[OptimizationStream] Job ${job.jobId} timed out after 5 minutes, killing process`);
-      childProcess.kill('SIGTERM');
+    // Only one terminal path may call onError/onComplete + processQueue.
+    // Timeout kill still emits `close`; without this flag both paths double-fire.
+    let finished = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const finishJob = (handler: () => void) => {
+      if (finished) return;
+      finished = true;
+      if (timeout !== undefined) clearTimeout(timeout);
       activeJobs.delete(childProcess);
-      job.onError('Optimization timed out');
+      handler();
       processQueue();
+    };
+
+    // Add timeout to prevent hung processes (5 minutes)
+    timeout = setTimeout(() => {
+      error(`[OptimizationStream] Job ${job.jobId} timed out after 5 minutes, killing process`);
+      // Kill first so the process begins exiting; finishJob guards the subsequent close.
+      childProcess.kill('SIGTERM');
+      finishJob(() => {
+        job.onError('Optimization timed out');
+      });
     }, 5 * 60 * 1000);
 
     // Handle stdout for progress updates
@@ -140,28 +154,23 @@ async function processQueue() {
 
     // Handle completion
     childProcess.on('close', (code) => {
-      clearTimeout(timeout);
-      activeJobs.delete(childProcess);
-
-      if (code === 0) {
-        job.onComplete();
-        // info(`[OptimizationStream] Completed ${job.jobId} (${activeJobs.size}/${MAX_CONCURRENT_JOBS} active, ${optimizationQueue.length} queued)`);
-      } else {
-        job.onError(`Optimization failed with code ${code}`);
-        error(`[OptimizationStream] Failed ${job.jobId} with code ${code} (${activeJobs.size}/${MAX_CONCURRENT_JOBS} active, ${optimizationQueue.length} queued)`);
-      }
-
-      // Process next job in queue
-      processQueue();
+      finishJob(() => {
+        if (code === 0) {
+          job.onComplete();
+          // info(`[OptimizationStream] Completed ${job.jobId} (${activeJobs.size}/${MAX_CONCURRENT_JOBS} active, ${optimizationQueue.length} queued)`);
+        } else {
+          job.onError(`Optimization failed with code ${code}`);
+          error(`[OptimizationStream] Failed ${job.jobId} with code ${code} (${activeJobs.size}/${MAX_CONCURRENT_JOBS} active, ${optimizationQueue.length} queued)`);
+        }
+      });
     });
 
     // Handle errors
     childProcess.on('error', (err) => {
-      clearTimeout(timeout);
-      activeJobs.delete(childProcess);
-      error(`[OptimizationStream] Error in job ${job.jobId}:`, err);
-      job.onError(err.message);
-      processQueue();
+      finishJob(() => {
+        error(`[OptimizationStream] Error in job ${job.jobId}:`, err);
+        job.onError(err.message);
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary
Optimization jobs that hit the 5-minute timeout were calling `onError` and `processQueue` twice: once in the timeout handler and again when the killed child emitted `close`. That double-broadcast SSE errors and could start two queued jobs when capacity was freed twice, overshooting `MAX_CONCURRENT_JOBS`.

## Change
- Gate timeout / close / error through a single `finishJob` helper with a `finished` flag in `backend/src/routes/optimization-stream.ts`.
- First terminal path wins; subsequent close after SIGTERM is a no-op.

## Test plan
- [ ] Timeout path: hung optimize job past 5m → one error broadcast, one queue drain
- [ ] Normal success/failure exit still completes once
- [ ] Spawn error path still reports once without double processQueue

Ticket #2745