### PR TITLE
fix: require admin and CSRF for system restart (ticket #2740)

### DIFF
--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -8,7 +8,8 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { requireAuth } from '../auth/middleware.js';
+import { requireAdmin } from '../auth/middleware.js';
+import { csrfProtection } from '../security.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,8 +17,8 @@ const __dirname = path.dirname(__filename);
 
 const router = Router();
 
-// Restart endpoint - triggers container restart or PM2 restart
-router.post('/restart', requireAuth, (req, res) => {
+// Restart endpoint - admin only (system settings); CSRF like other mutating routes
+router.post('/restart', csrfProtection, requireAdmin, (req, res) => {
   try {
     // Get user info for logging
     const userId = (req.session as any)?.userId;


### PR DESCRIPTION
## Summary
- Gates `POST /api/system/restart` with `requireAdmin` instead of `requireAuth` so viewers/managers cannot take the stack down.
- Adds `csrfProtection` on the same route, consistent with other mutating admin routes.

## Context
Felix finding: any logged-in user could hit restart and trigger `pm2 restart all` or `process.exit(0)`. Middleware docs treat system settings as admin-only; managers are content-only, viewers read-only.

## Test plan
- [ ] As admin: restart from config UI still works (`RestartModal` → 200).
- [ ] As manager/viewer: `POST /api/system/restart` with session cookies returns 403.
- [ ] Unauthenticated: 401.
- [ ] Cross-origin POST without allowed Origin: 403 from CSRF.