### PR TITLE
fix: unlink multer temp file on rejected upload paths (ticket #2744)

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -432,6 +432,19 @@ const sanitizeName = (name: string): string | null => {
 };
 
 /**
+ * Best-effort cleanup of a multer diskStorage temp file.
+ * Safe to call when the path is missing or already unlinked.
+ */
+const unlinkTempUpload = (filePath: string | undefined | null): void => {
+  if (!filePath) return;
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Ignore cleanup errors (already moved/deleted, or race)
+  }
+};
+
+/**
  * Sanitize photo/video filename by removing/replacing invalid characters
  * Converts to Title Case for consistency
  */
@@ -879,6 +892,8 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
     
     const sanitizedAlbum = sanitizeName(album);
     if (!sanitizedAlbum) {
+      // Multer may already have written the file to os.tmpdir()
+      unlinkTempUpload(req.file?.path);
       res.status(400).json({ error: 'Invalid album name' });
       return;
     }
@@ -892,6 +907,7 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
     // SECURITY: Sanitize filename to prevent path traversal attacks
     const sanitizedFilename = sanitizePhotoName(file.originalname);
     if (!sanitizedFilename) {
+      unlinkTempUpload(file.path);
       res.status(400).json({ error: 'Invalid filename. Use only alphanumeric characters, spaces, hyphens, underscores, and valid image/video extensions.' });
       return;
     }
@@ -900,6 +916,7 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
     const albumPath = path.join(photosDir, sanitizedAlbum);
     
     if (!fs.existsSync(albumPath)) {
+      unlinkTempUpload(file.path);
       res.status(404).json({ error: 'Album not found' });
       return;
     }
@@ -1123,6 +1140,8 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
       }
     }
   } catch (err) {
+    // Drop multer temp file on any unexpected failure path
+    unlinkTempUpload(req.file?.path);
     error('[AlbumManagement] Failed to upload file:', err);
     res.status(500).json({ error: 'Failed to upload file' });
   }


### PR DESCRIPTION
## Summary
After multer `diskStorage` accepts an upload into `os.tmpdir()`, the `POST /:album/upload` handler could reject invalid filenames, missing albums, or invalid album names with 400/404 and return without unlinking `req.file.path`. The outer catch had the same leak. Large temp files could accumulate on every rejected attempt.

## Changes
- Add `unlinkTempUpload` helper (best-effort `fs.unlinkSync`, ignore cleanup errors)
- Call it on early returns: invalid album name, invalid filename, album not found
- Call it in the outer catch of the upload handler
- Success and processing-error paths already unlinked; left as-is

## Ticket
#2744

## Test plan
- [ ] Upload with invalid filename → 400 and no leftover file under system temp
- [ ] Upload to non-existent album → 404 and temp removed
- [ ] Valid upload still succeeds (temp cleaned after move/process as before)