### PR TITLE
fix: reject inactive users on passkey auth-verify (ticket #2739)

### DIFF
--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1287,6 +1287,11 @@ router.post('/passkey/auth-verify', async (req: Request, res: Response) => {
 
     const { user, passkey } = result;
 
+    // Reject disabled accounts (same guard as password /login)
+    if (!user.is_active) {
+      return res.status(401).json({ error: 'Account is disabled' });
+    }
+
     // Verify authentication
     const verification = await verifyPasskeyAuthentication(
       credential,


### PR DESCRIPTION
## Summary
Passkey login (`POST /passkey/auth-verify`) wrote a session after successful WebAuthn verification without checking `user.is_active`. Deactivated users who still had a registered passkey could obtain a fresh session. Password `/login` already rejects inactive accounts with 401.

## Change
- After resolving the passkey owner, return `401` with `"Account is disabled"` if `!user.is_active`, before verification/session write.
- Matches the guard used by password login in the same file.

## Test plan
- [ ] Active user: passkey login still succeeds
- [ ] Deactivate a user who has a passkey, complete passkey auth-verify → 401, no session
- [ ] Password login for same inactive user still 401 (unchanged)

Closes ticket #2739