### PR TITLE
fix: reject deactivated users in requireAuth (ticket #2738)

### DIFF
--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -30,7 +30,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
   if (req.isAuthenticated && req.isAuthenticated()) {
     const sessionUser = req.user as any;
     
-    // Verify user still exists in database
+    // Verify user still exists and is active in database
     if (sessionUser?.email) {
       const dbUser = getUserByEmail(sessionUser.email);
       if (!dbUser) {
@@ -42,6 +42,14 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
         req.session.destroy(() => {});
         return res.status(401).json({ error: 'User account no longer exists' });
       }
+      if (!dbUser.is_active) {
+        trace('[Auth Middleware] User deactivated (Google OAuth):', sessionUser.email);
+        req.logout((err) => {
+          if (err) trace('[Auth Middleware] Logout error:', err);
+        });
+        req.session.destroy(() => {});
+        return res.status(401).json({ error: 'Account is disabled' });
+      }
     }
     
     trace('[Auth Middleware] Authenticated via Passport');
@@ -52,13 +60,18 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
   if ((req.session as any)?.userId) {
     const userId = (req.session as any).userId;
     
-    // Verify user still exists in database
+    // Verify user still exists and is active in database
     const dbUser = getUserById(userId);
     if (!dbUser) {
       trace('[Auth Middleware] User no longer exists (credentials):', userId);
       // Destroy session and return 401
       req.session.destroy(() => {});
       return res.status(401).json({ error: 'User account no longer exists' });
+    }
+    if (!dbUser.is_active) {
+      trace('[Auth Middleware] User deactivated (credentials):', userId);
+      req.session.destroy(() => {});
+      return res.status(401).json({ error: 'Account is disabled' });
     }
     
     trace('[Auth Middleware] Authenticated via credentials');


### PR DESCRIPTION
## Summary
- `requireAuth` now checks `user.is_active` after the existing DB existence check (Passport + credential sessions).
- Inactive users get the same treatment as deleted ones: session destroyed, `401` with `Account is disabled` (matches login).

## Context
Deactivating a user (`is_active=0`) while they already have a session left protected routes fully open. Login already blocked inactive accounts; middleware did not.

## Test plan
- [ ] Log in as a user, then set `is_active=0` for that user in the DB
- [ ] Call any `requireAuth` route with the existing session cookie → expect `401` and session cleared
- [ ] Confirm active users still pass `requireAuth` normally
- [ ] Confirm login still rejects inactive users with the same error string

Ticket #2738