### PR TITLE
fix: log SW registration failures without shadowing error (ticket #2743)

### DIFF
--- a/frontend/src/utils/serviceWorker.ts
+++ b/frontend/src/utils/serviceWorker.ts
@@ -3,7 +3,7 @@
  * Registers and manages the service worker for caching
  */
 
-import { info } from '../utils/logger';
+import { info, error as logError } from '../utils/logger';
 
 export function registerServiceWorker() {
   // Disable service worker on localhost (development)
@@ -74,7 +74,7 @@ export function registerServiceWorker() {
           });
         })
         .catch((error) => {
-          error("Service Worker registration failed:", error);
+          logError("Service Worker registration failed:", error);
         });
 
       // Listen for messages from the service worker
@@ -94,7 +94,7 @@ export function unregisterServiceWorker() {
         registration.unregister();
       })
       .catch((error) => {
-        error("Service Worker unregistration failed:", error);
+        logError("Service Worker unregistration failed:", error);
       });
   }
 }


### PR DESCRIPTION
## Summary
Service worker catch handlers bound the rejection as `error` then called `error(...)` as if it were the logger. Only `info` was imported, so a real SW registration failure became a TypeError in the catch path.

## Changes
- Import `error as logError` from the frontend logger (same pattern as AuthContext / SetupWizard).
- Use `logError` in register and unregister `.catch` handlers so the original failure is logged.

## Test plan
- [ ] Confirm catch paths no longer call the rejection value as a function.
- [ ] Optional: force SW register failure on an HTTPS host and verify the log message appears without a secondary TypeError.