### PR TITLE
fix: reload role from DB in requireManager/requireAdmin (ticket #2737)

### DIFF
--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -76,40 +76,72 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
 export const isAuthenticated = requireAuth;
 
 /**
- * Helper function to get user from request with role lookup from database
+ * Build privileged-check user from a live DB row.
+ * Role and is_active must never come from session snapshots (frozen at login).
+ */
+function userFromDb(dbUser: NonNullable<ReturnType<typeof getUserById>>, sessionUser: any = {}) {
+  return {
+    ...sessionUser,
+    id: dbUser.id,
+    email: dbUser.email,
+    name: dbUser.name ?? sessionUser.name,
+    picture: dbUser.picture ?? sessionUser.picture,
+    role: dbUser.role,
+    is_active: dbUser.is_active,
+    mfa_enabled: dbUser.mfa_enabled,
+    auth_methods: dbUser.auth_methods,
+  };
+}
+
+/**
+ * Helper function to get user from request with role lookup from database.
+ * Always reloads role and is_active from the DB so demotion/deactivation
+ * take effect without requiring re-login.
  */
 async function getUserFromRequest(req: Request): Promise<any> {
-  // Check credential session first (has full user data including role)
-  if ((req.session as any)?.user) {
-    return (req.session as any).user;
+  // Credential session: session.user.role is a login-time snapshot — ignore it
+  if ((req.session as any)?.userId) {
+    const userId = (req.session as any).userId;
+    const dbUser = getUserById(userId);
+    if (!dbUser) {
+      return null;
+    }
+    return userFromDb(dbUser, (req.session as any).user || {});
   }
-  
-  // Check Passport session (Google OAuth) - need to look up role from DB
+
+  // Passport session (Google OAuth) — always look up role from DB
   if (req.user) {
     const sessionUser = req.user as any;
-    
-    // If user already has role, return it
-    if (sessionUser.role) {
-      return sessionUser;
+    let dbUser = sessionUser.email ? getUserByEmail(sessionUser.email) : null;
+    if (!dbUser && typeof sessionUser.id === 'number') {
+      dbUser = getUserById(sessionUser.id);
     }
-    
-    // Look up user in database to get role
+    if (!dbUser) {
+      return null;
+    }
+    return userFromDb(dbUser, sessionUser);
+  }
+
+  // Defensive: credential session with user blob but missing userId
+  if ((req.session as any)?.user) {
+    const sessionUser = (req.session as any).user;
+    if (sessionUser.id != null) {
+      const id = typeof sessionUser.id === 'string' ? parseInt(sessionUser.id, 10) : sessionUser.id;
+      if (!Number.isNaN(id)) {
+        const dbUser = getUserById(id);
+        if (dbUser) {
+          return userFromDb(dbUser, sessionUser);
+        }
+      }
+    }
     if (sessionUser.email) {
       const dbUser = getUserByEmail(sessionUser.email);
       if (dbUser) {
-        // Return combined user object with role from database
-        return {
-          ...sessionUser,
-          role: dbUser.role,
-          id: dbUser.id,
-        };
+        return userFromDb(dbUser, sessionUser);
       }
     }
-    
-    // Fallback - return session user (likely won't have role)
-    return sessionUser;
   }
-  
+
   return null;
 }
 
@@ -126,19 +158,25 @@ export async function requireAdmin(req: Request, res: Response, next: NextFuncti
     return res.status(401).json({ error: 'Not authenticated' });
   }
   
-  // Get user and check role
+  // Get user and check role (fresh from DB — not session snapshot)
   const user = await getUserFromRequest(req);
   
   trace('[Admin Middleware] User lookup result:', {
     hasUser: !!user,
     email: user?.email,
     role: user?.role,
+    is_active: user?.is_active,
     id: user?.id,
   });
   
   if (!user || !user.role) {
     trace('[Admin Middleware] No user or role found');
     return res.status(403).json({ error: 'Access denied - role required' });
+  }
+
+  if (user.is_active === false) {
+    trace('[Admin Middleware] User is inactive:', user.email);
+    return res.status(401).json({ error: 'Account is disabled' });
   }
   
   if (user.role !== 'admin') {
@@ -166,12 +204,17 @@ export async function requireManager(req: Request, res: Response, next: NextFunc
     return res.status(401).json({ error: 'Not authenticated' });
   }
   
-  // Get user and check role
+  // Get user and check role (fresh from DB — not session snapshot)
   const user = await getUserFromRequest(req);
   
   if (!user || !user.role) {
     trace('[Manager Middleware] No user or role found');
     return res.status(403).json({ error: 'Access denied - role required' });
+  }
+
+  if (user.is_active === false) {
+    trace('[Manager Middleware] User is inactive:', user.email);
+    return res.status(401).json({ error: 'Account is disabled' });
   }
   
   if (user.role !== 'admin' && user.role !== 'manager') {


### PR DESCRIPTION
## Summary
`requireManager` / `requireAdmin` trusted `session.user.role` frozen at login. Demoting a manager to viewer left their cookie able to hit content/admin APIs until re-login.

## Change
- `getUserFromRequest` always loads `role` and `is_active` from the DB (credential `userId`, Passport email/id, defensive session.user fallback).
- Privileged middlewares reject inactive accounts with 401.

## Test plan
- [ ] Login as manager, keep session, admin demotes to viewer via PATCH role — next manager-only API returns 403 without re-login
- [ ] Admin role still passes `requireAdmin` after a normal session
- [ ] Google OAuth admin/manager still authorized after role is set in DB
- [ ] Deactivated user with live session fails privileged checks