### PR TITLE
[security-audit] Password change/reset does not invalidate existing sessions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/auth/session-invalidation.test.ts
+++ b/backend/src/auth/session-invalidation.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  destroySessionsForUser,
+  sessionBelongsToUser,
+  type SessionRecord,
+  type SessionStoreLike,
+} from './session-invalidation.js';
+
+test('sessionBelongsToUser matches credential userId', () => {
+  assert.equal(sessionBelongsToUser({ userId: 42 }, 42), true);
+  assert.equal(sessionBelongsToUser({ userId: '42' }, 42), true);
+  assert.equal(sessionBelongsToUser({ userId: 7 }, 42), false);
+});
+
+test('sessionBelongsToUser matches credential session.user blob', () => {
+  assert.equal(
+    sessionBelongsToUser({ user: { id: 3, email: 'a@example.com' } }, 3, 'a@example.com'),
+    true
+  );
+  assert.equal(
+    sessionBelongsToUser({ user: { email: 'a@example.com' } }, 99, 'a@example.com'),
+    true
+  );
+  assert.equal(
+    sessionBelongsToUser({ user: { id: 3, email: 'other@example.com' } }, 99, 'a@example.com'),
+    false
+  );
+});
+
+test('sessionBelongsToUser matches passport email object (Google OAuth)', () => {
+  const session: SessionRecord = {
+    passport: { user: { id: 'google-sub', email: 'admin@example.com', name: 'Admin' } },
+  };
+  assert.equal(sessionBelongsToUser(session, 1, 'admin@example.com'), true);
+  assert.equal(sessionBelongsToUser(session, 1, 'ADMIN@example.com'), true);
+  assert.equal(sessionBelongsToUser(session, 1, 'other@example.com'), false);
+  // Old delete-user matcher (passport.user === userId) would miss this
+  assert.equal(session.passport?.user === 1, false);
+});
+
+test('sessionBelongsToUser matches scalar passport user id', () => {
+  assert.equal(sessionBelongsToUser({ passport: { user: 9 } }, 9), true);
+  assert.equal(sessionBelongsToUser({ passport: { user: '9' } }, 9), true);
+  assert.equal(sessionBelongsToUser({ passport: { user: 'user@x.com' } }, 1, 'user@x.com'), true);
+});
+
+test('sessionBelongsToUser rejects empty/unrelated sessions', () => {
+  assert.equal(sessionBelongsToUser(undefined, 1), false);
+  assert.equal(sessionBelongsToUser({}, 1, 'a@b.c'), false);
+  assert.equal(sessionBelongsToUser({ cookie: {} } as SessionRecord, 1), false);
+});
+
+test('destroySessionsForUser destroys matching sids only', async () => {
+  const destroyed: string[] = [];
+  const store: SessionStoreLike = {
+    all(cb) {
+      cb(null, {
+        sidA: { userId: 1 },
+        sidB: { userId: 2 },
+        sidC: { passport: { user: { email: 'one@example.com' } } },
+        sidD: {},
+      });
+    },
+    destroy(sid, cb) {
+      destroyed.push(sid);
+      cb?.();
+    },
+  };
+
+  const count = await destroySessionsForUser(store, 1, 'one@example.com', 'test');
+  assert.equal(count, 2);
+  assert.deepEqual(destroyed.sort(), ['sidA', 'sidC']);
+});
+
+test('destroySessionsForUser resolves 0 when store has no all()', async () => {
+  const store: SessionStoreLike = {
+    destroy() {},
+  };
+  const count = await destroySessionsForUser(store, 1);
+  assert.equal(count, 0);
+});

--- a/backend/src/auth/session-invalidation.ts
+++ b/backend/src/auth/session-invalidation.ts
@@ -1,0 +1,158 @@
+/**
+ * Destroy all express-session store entries that belong to a given user.
+ * Used after password change/reset (and user deletion) so stolen cookies die immediately.
+ */
+
+import { error, info } from '../utils/logger.js';
+
+export type SessionRecord = {
+  userId?: number | string;
+  user?: {
+    id?: number | string;
+    email?: string;
+  };
+  passport?: {
+    user?: number | string | {
+      id?: number | string;
+      email?: string;
+    };
+  };
+};
+
+export type SessionStoreLike = {
+  all?: (
+    callback: (err: Error | null, sessions: Record<string, SessionRecord> | SessionRecord[] | null) => void
+  ) => void;
+  destroy: (sid: string, callback?: (err?: Error) => void) => void;
+};
+
+/**
+ * True when a stored session is authenticated as the given user.
+ * Credential sessions: session.userId / session.user.id
+ * Passport (Google): session.passport.user.email (or legacy id scalar)
+ */
+export function sessionBelongsToUser(
+  session: SessionRecord | null | undefined,
+  userId: number,
+  userEmail?: string | null
+): boolean {
+  if (!session) return false;
+
+  if (session.userId != null && Number(session.userId) === userId) {
+    return true;
+  }
+
+  if (session.user?.id != null && Number(session.user.id) === userId) {
+    return true;
+  }
+
+  if (userEmail) {
+    const email = userEmail.toLowerCase();
+    if (session.user?.email && session.user.email.toLowerCase() === email) {
+      return true;
+    }
+  }
+
+  const passportUser = session.passport?.user;
+  if (passportUser == null) {
+    return false;
+  }
+
+  if (typeof passportUser === 'object') {
+    if (passportUser.id != null && Number(passportUser.id) === userId) {
+      return true;
+    }
+    if (
+      userEmail &&
+      passportUser.email &&
+      passportUser.email.toLowerCase() === userEmail.toLowerCase()
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  // Scalar passport user (numeric id or email string)
+  if (typeof passportUser === 'number' || /^\d+$/.test(String(passportUser))) {
+    return Number(passportUser) === userId;
+  }
+
+  if (userEmail && String(passportUser).toLowerCase() === userEmail.toLowerCase()) {
+    return true;
+  }
+
+  return false;
+}
+
+function normalizeSessions(
+  sessions: Record<string, SessionRecord> | SessionRecord[] | null | undefined
+): Array<[string, SessionRecord]> {
+  if (!sessions) return [];
+
+  if (Array.isArray(sessions)) {
+    // Some stores return an array; sid may live on the object
+    return sessions
+      .map((session, index) => {
+        const sid =
+          (session as SessionRecord & { id?: string; sid?: string }).id ||
+          (session as SessionRecord & { sid?: string }).sid ||
+          String(index);
+        return [sid, session] as [string, SessionRecord];
+      });
+  }
+
+  return Object.entries(sessions);
+}
+
+/**
+ * Destroy every session in the store that matches userId / userEmail.
+ * Resolves when all destroy callbacks finish (or immediately if store has no .all).
+ */
+export function destroySessionsForUser(
+  sessionStore: SessionStoreLike | undefined | null,
+  userId: number,
+  userEmail?: string | null,
+  logContext = 'password-change'
+): Promise<number> {
+  return new Promise((resolve) => {
+    if (!sessionStore?.all) {
+      resolve(0);
+      return;
+    }
+
+    sessionStore.all((err, sessions) => {
+      if (err) {
+        error(`[Session] Failed to list sessions for ${logContext}:`, err);
+        resolve(0);
+        return;
+      }
+
+      const entries = normalizeSessions(sessions).filter(([, session]) =>
+        sessionBelongsToUser(session, userId, userEmail)
+      );
+
+      if (entries.length === 0) {
+        resolve(0);
+        return;
+      }
+
+      let remaining = entries.length;
+      let destroyed = 0;
+
+      for (const [sid] of entries) {
+        sessionStore.destroy(sid, (destroyErr) => {
+          if (destroyErr) {
+            error(`[Session] Failed to destroy session ${sid}:`, destroyErr);
+          } else {
+            destroyed += 1;
+            info(`[Session] Destroyed session ${sid} for user ${userId} (${logContext})`);
+          }
+          remaining -= 1;
+          if (remaining === 0) {
+            resolve(destroyed);
+          }
+        });
+      }
+    });
+  });
+}

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -48,6 +48,7 @@ import { sendInvitationEmail, sendPasswordResetEmail, isEmailServiceEnabled, gen
 import { getCurrentConfig, reloadConfig } from '../config.js';
 import { sendNotificationToUser } from '../push-notifications.js';
 import { translateNotification } from '../i18n-backend.js';
+import { destroySessionsForUser } from '../auth/session-invalidation.js';
 
 const router = Router();
 
@@ -722,6 +723,14 @@ router.post('/password-reset/:token/complete', async (req: Request, res: Respons
     // Clear reset token
     clearPasswordResetToken(user.id);
 
+    // Invalidate every existing session for this user (stolen cookies must not survive reset)
+    await destroySessionsForUser(
+      req.sessionStore as any,
+      user.id,
+      user.email,
+      'password-reset'
+    );
+
     // Send push notification to all admins
     await notifyAllAdmins(
       'notifications.backend.passwordChangedTitle',
@@ -883,21 +892,35 @@ router.post('/change-password', requireAuth, async (req: Request, res: Response)
     // Update password
     updatePassword(userId, newPassword);
 
-    // Send push notification to all admins
-    if (user) {
-      await notifyAllAdmins(
-        'notifications.backend.passwordChangedTitle',
-        'notifications.backend.passwordChangedBody',
-        'password-changed',
-        'passwordChanged',
-        {
-          userName: user.name || user.email,
-          userEmail: user.email
-        }
-      ).catch(err => error('[AuthExtended] Failed to send password change notification:', err));
-    }
+    // Invalidate every session for this user (including other devices / stolen cookies)
+    await destroySessionsForUser(
+      req.sessionStore as any,
+      userId,
+      user.email,
+      'change-password'
+    );
 
-    res.json({ success: true });
+    // Send push notification to all admins
+    await notifyAllAdmins(
+      'notifications.backend.passwordChangedTitle',
+      'notifications.backend.passwordChangedBody',
+      'password-changed',
+      'passwordChanged',
+      {
+        userName: user.name || user.email,
+        userEmail: user.email
+      }
+    ).catch(err => error('[AuthExtended] Failed to send password change notification:', err));
+
+    // Force re-login on the current client as well
+    req.session.destroy((destroyErr) => {
+      if (destroyErr) {
+        error('[AuthExtended] Failed to destroy current session after password change:', destroyErr);
+        // Password already updated and other sessions wiped; still report success
+        return res.json({ success: true, requiresReauth: true });
+      }
+      res.json({ success: true, requiresReauth: true });
+    });
   } catch (err) {
     error('[AuthExtended] Password change error:', err);
     res.status(500).json({ error: 'Password change failed' });
@@ -1527,32 +1550,13 @@ router.delete('/users/:userId', requireAdmin, async (req: Request, res: Response
       }
     ).catch(err => error('[AuthExtended] Failed to send user deletion notification:', err));
     
-    // Invalidate all sessions for this user
-    const sessionStore = req.sessionStore;
-    if (sessionStore && sessionStore.all) {
-      sessionStore.all((err: Error | null, sessions: any) => {
-        if (err) {
-          error('[AuthExtended] Failed to getting sessions:', err);
-          return;
-        }
-        
-        // Destroy sessions belonging to the deleted user
-        if (sessions) {
-          Object.keys(sessions).forEach((sid) => {
-            const session = sessions[sid];
-            if (session?.passport?.user === userId) {
-              sessionStore.destroy(sid, (destroyErr) => {
-                if (destroyErr) {
-                  error(`Failed to destroy session ${sid}:`, destroyErr);
-                } else {
-                  info(`[Session] Destroyed session ${sid} for deleted user ${userId}`);
-                }
-              });
-            }
-          });
-        }
-      });
-    }
+    // Invalidate all sessions for this user (credential userId + passport email)
+    await destroySessionsForUser(
+      req.sessionStore as any,
+      userId,
+      targetUser.email,
+      'user-deleted'
+    );
     
     info(`[User Management] User ${targetUser.email} (ID: ${userId}) deleted by user ID: ${currentUserId}`);
     


### PR DESCRIPTION
# Summary — #3253 Password change/reset session invalidation

## Finding
Confirmed. `POST /api/auth-extended/change-password` and `POST /api/auth-extended/password-reset/:token/complete` only updated the password hash. SQLite-backed `connect.sid` rows for that user kept `session.userId` / passport identity until cookie expiry (24h rolling).

## Fix
- Added `backend/src/auth/session-invalidation.ts`:
  - `sessionBelongsToUser` — matches credential `userId` / `user.id` / `user.email` and passport email (or scalar id)
  - `destroySessionsForUser` — walks `sessionStore.all` and destroys matches
- Wired after successful password update on both change-password and password-reset complete.
- Change-password also calls `req.session.destroy` and returns `{ success: true, requiresReauth: true }` so the current client must re-login.
- Delete-user session wipe now uses the same helper (old path only checked `passport.user === userId`, which missed credential sessions and object-shaped passport users).

## Files
- `backend/src/auth/session-invalidation.ts` (new)
- `backend/src/auth/session-invalidation.test.ts` (new)
- `backend/src/routes/auth-extended.ts`
- `backend/package.json` (test script includes new file)

## Verification
```
npm ci --cache /tmp/npm-cache-galleria-3253
npm test --prefix backend
# 15 pass, 0 fail (7 session-invalidation + 8 album-access)
```

Implements Orchestrator ticket #3253.