### PR TITLE
[security-audit] Deleted-user sessions still open private albums; wipe matcher broken

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/utils/session-user.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/albums.ts
+++ b/backend/src/routes/albums.ts
@@ -25,7 +25,7 @@ import {
   getAlbumsInFolder,
   incrementAlbumViewCount
 } from "../database.js";
-import { getAlbumAccess } from '../utils/album-access.js';
+import { getAlbumAccess, isRequestAuthenticated } from '../utils/album-access.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 
 const router = Router();
@@ -252,8 +252,8 @@ router.get("/api/albums", (req: Request, res) => {
   // Re-fetch album states after sync
   const updatedAlbumStates = getAllAlbums();
   
-  // Check if user is authenticated (Passport or credentials)
-  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
+  // Live DB check — deleted/inactive sessions must not list unpublished albums
+  const isAuthenticated = isRequestAuthenticated(req);
   
   verbose('[Albums] Auth check:', {
     isAuthenticated,

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -6,6 +6,7 @@
 import { Router, Request, Response } from 'express';
 import { requireAuth, requireAdmin } from '../auth/middleware.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
+import { sessionBelongsToUser } from '../utils/session-user.js';
 import {
   getUserById,
   updateUser,
@@ -1527,8 +1528,12 @@ router.delete('/users/:userId', requireAdmin, async (req: Request, res: Response
       }
     ).catch(err => error('[AuthExtended] Failed to send user deletion notification:', err));
     
-    // Invalidate all sessions for this user
+    // Invalidate all sessions for this user.
+    // Credential sessions set session.userId; Passport stores
+    // session.passport.user as { id: googleProfileId, email, ... } — never
+    // compare the whole object to the DB numeric id.
     const sessionStore = req.sessionStore;
+    const deletedEmail = targetUser.email;
     if (sessionStore && sessionStore.all) {
       sessionStore.all((err: Error | null, sessions: any) => {
         if (err) {
@@ -1536,11 +1541,10 @@ router.delete('/users/:userId', requireAdmin, async (req: Request, res: Response
           return;
         }
         
-        // Destroy sessions belonging to the deleted user
         if (sessions) {
           Object.keys(sessions).forEach((sid) => {
             const session = sessions[sid];
-            if (session?.passport?.user === userId) {
+            if (sessionBelongsToUser(session, userId, deletedEmail)) {
               sessionStore.destroy(sid, (destroyErr) => {
                 if (destroyErr) {
                   error(`Failed to destroy session ${sid}:`, destroyErr);

--- a/backend/src/routes/video.ts
+++ b/backend/src/routes/video.ts
@@ -9,6 +9,7 @@ import path from "path";
 import { error, info } from '../utils/logger.js';
 import { getAlbumState, getShareLinkBySecret, isShareLinkExpired } from '../database.js';
 import { requireAuth } from '../auth/middleware.js';
+import { isRequestAuthenticated } from '../utils/album-access.js';
 
 const router = Router();
 
@@ -87,8 +88,8 @@ const sendPlaylist = (req: Request, res: Response, playlistPath: string): void =
  * Check if user has access to album (authenticated, published, or valid share link)
  */
 const hasAlbumAccess = (req: Request, album: string): boolean => {
-  // Check authentication
-  const isAuthenticated = (req.isAuthenticated && req.isAuthenticated()) || !!(req.session as any)?.userId;
+  // Live DB check — deleted/inactive sessions must not stream unpublished video
+  const isAuthenticated = isRequestAuthenticated(req);
   
   const shareKey = getShareKeyFromQuery(req);
   let hasValidShareLink = false;

--- a/backend/src/utils/album-access.test.ts
+++ b/backend/src/utils/album-access.test.ts
@@ -20,10 +20,15 @@ interface AccessResult {
 
 interface AlbumAccessModule {
   getAlbumAccess(req: Request, albumName: string): AccessResult;
+  isRequestAuthenticated(req: Request): boolean;
 }
 
 interface RequestOptions {
   authenticated?: boolean;
+  /** Credential session userId override (defaults to active test user) */
+  userId?: number;
+  /** Passport-style session: isAuthenticated + req.user.email */
+  passportEmail?: string;
   key?: string;
 }
 
@@ -34,11 +39,26 @@ let albumsRouter: Router;
 let generateStaticJSONFiles: (appRoot: string) => Promise<{ success: boolean; error?: string; albumCount?: number }>;
 let shareKey = '';
 let expiredShareKey = '';
+let activeUserId = 0;
+let inactiveUserId = 0;
+const activeUserEmail = 'active@example.com';
+const inactiveUserEmail = 'inactive@example.com';
+const deletedUserEmail = 'deleted@example.com';
 
 function request(options: RequestOptions = {}): Request {
+  if (options.passportEmail) {
+    return {
+      isAuthenticated: () => true,
+      user: { id: 'google-profile-id', email: options.passportEmail },
+      session: { passport: { user: { id: 'google-profile-id', email: options.passportEmail } } },
+      query: options.key ? { key: options.key } : {},
+    } as unknown as Request;
+  }
+
+  const userId = options.userId ?? activeUserId;
   return {
     isAuthenticated: () => Boolean(options.authenticated),
-    session: options.authenticated ? { userId: 1 } : {},
+    session: options.authenticated ? { userId } : {},
     query: options.key ? { key: options.key } : {},
   } as unknown as Request;
 }
@@ -51,7 +71,7 @@ function createRouteApp(): Express {
   app.use((req, _res, next) => {
     const authenticated = req.get('x-test-auth') === '1';
     (req as any).isAuthenticated = () => authenticated;
-    (req as any).session = authenticated ? { userId: 1 } : {};
+    (req as any).session = authenticated ? { userId: activeUserId } : {};
     next();
   });
   app.use('/api/image-metadata', imageMetadataRouter);
@@ -127,13 +147,71 @@ test.before(async () => {
   ]);
 
   const database = await import('../database.js');
+  const databaseUsers = await import('../database-users.js');
   albumAccess = await import('./album-access.js');
   imageMetadataRouter = (await import('../routes/image-metadata.js')).default;
   previewGridRouter = (await import('../routes/preview-grid.js')).default;
   albumsRouter = (await import('../routes/albums.js')).default;
   ({ generateStaticJSONFiles } = await import('../routes/static-json.js'));
 
-  database.initializeDatabase();
+  const db = database.initializeDatabase();
+  // Users table is normally created during setup; create it here for auth checks
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT,
+      auth_methods TEXT NOT NULL DEFAULT '["google"]',
+      mfa_enabled INTEGER NOT NULL DEFAULT 0,
+      totp_secret TEXT,
+      backup_codes TEXT,
+      passkeys TEXT,
+      google_id TEXT UNIQUE,
+      name TEXT,
+      picture TEXT,
+      role TEXT NOT NULL DEFAULT 'viewer',
+      is_active INTEGER NOT NULL DEFAULT 1,
+      email_verified INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active',
+      invite_token TEXT UNIQUE,
+      invite_expires_at TEXT,
+      password_reset_token TEXT UNIQUE,
+      password_reset_expires_at TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      last_login_at TEXT
+    )
+  `);
+
+  const activeUser = databaseUsers.createUser({
+    email: activeUserEmail,
+    name: 'Active User',
+    auth_methods: ['password'],
+    email_verified: true,
+    role: 'viewer',
+  });
+  activeUserId = activeUser.id;
+
+  const inactiveUser = databaseUsers.createUser({
+    email: inactiveUserEmail,
+    name: 'Inactive User',
+    auth_methods: ['password'],
+    email_verified: true,
+    role: 'viewer',
+  });
+  inactiveUserId = inactiveUser.id;
+  databaseUsers.updateUser(inactiveUserId, { is_active: false });
+
+  // Create then delete so isRequestAuthenticated rejects leftover sessions
+  const deletedUser = databaseUsers.createUser({
+    email: deletedUserEmail,
+    name: 'Deleted User',
+    auth_methods: ['password'],
+    email_verified: true,
+    role: 'viewer',
+  });
+  databaseUsers.deleteUser(deletedUser.id);
+
   database.saveAlbum('Published', true);
   database.saveAlbum('Private', false);
   database.saveAlbum('OtherPrivate', false);
@@ -166,6 +244,46 @@ test('allows authenticated access to unpublished albums', () => {
 
   assert.equal(access.allowed, true);
   assert.equal(access.reason, 'authenticated');
+});
+
+test('isRequestAuthenticated accepts live credential and passport sessions', () => {
+  assert.equal(albumAccess.isRequestAuthenticated(request({ authenticated: true })), true);
+  assert.equal(albumAccess.isRequestAuthenticated(request({ passportEmail: activeUserEmail })), true);
+  assert.equal(albumAccess.isRequestAuthenticated(request()), false);
+});
+
+test('isRequestAuthenticated rejects deleted or inactive user sessions', () => {
+  // Stale credential session pointing at a deleted user id
+  assert.equal(
+    albumAccess.isRequestAuthenticated(request({ authenticated: true, userId: 99999 })),
+    false
+  );
+
+  // Inactive account still has a cookie
+  assert.equal(
+    albumAccess.isRequestAuthenticated(request({ authenticated: true, userId: inactiveUserId })),
+    false
+  );
+
+  // Passport session whose email no longer maps to a user
+  assert.equal(
+    albumAccess.isRequestAuthenticated(request({ passportEmail: deletedUserEmail })),
+    false
+  );
+
+  // Passport session for deactivated account
+  assert.equal(
+    albumAccess.isRequestAuthenticated(request({ passportEmail: inactiveUserEmail })),
+    false
+  );
+
+  // Content path must deny unpublished album for deleted-user session
+  const deletedAccess = albumAccess.getAlbumAccess(
+    request({ authenticated: true, userId: 99999 }),
+    'Private'
+  );
+  assert.equal(deletedAccess.allowed, false);
+  assert.equal(deletedAccess.reason, 'denied');
 });
 
 test('allows share-link access only for the matching unexpired album', () => {

--- a/backend/src/utils/album-access.ts
+++ b/backend/src/utils/album-access.ts
@@ -1,5 +1,6 @@
 import type { Request } from 'express';
 import { getAlbumState, getShareLinkBySecret, isShareLinkExpired } from '../database.js';
+import { getUserByEmail, getUserById } from '../database-users.js';
 
 type AlbumState = NonNullable<ReturnType<typeof getAlbumState>>;
 
@@ -10,8 +11,34 @@ export interface AlbumAccessResult {
   reason: 'not_found' | 'published' | 'authenticated' | 'share_link' | 'denied';
 }
 
+/**
+ * True if the request has a live, active user session.
+ * Re-validates against the DB (same rules as requireAuth) so deleted or
+ * deactivated accounts do not retain access to unpublished content.
+ */
 export function isRequestAuthenticated(req: Request): boolean {
-  return Boolean((req.isAuthenticated && req.isAuthenticated()) || (req.session as any)?.userId);
+  // Credential login: session.userId is the DB numeric id
+  if ((req.session as any)?.userId != null) {
+    const userId = Number((req.session as any).userId);
+    if (!Number.isFinite(userId)) {
+      return false;
+    }
+    const dbUser = getUserById(userId);
+    return Boolean(dbUser && dbUser.is_active);
+  }
+
+  // Passport (Google OAuth): req.user is { id: googleProfileId, email, ... }
+  if (req.isAuthenticated && req.isAuthenticated()) {
+    const sessionUser = req.user as any;
+    if (sessionUser?.email) {
+      const dbUser = getUserByEmail(sessionUser.email);
+      return Boolean(dbUser && dbUser.is_active);
+    }
+    // Cannot verify without email — do not grant content access
+    return false;
+  }
+
+  return false;
 }
 
 export function getShareKeyFromRequest(req: Request): string | null {

--- a/backend/src/utils/session-user.test.ts
+++ b/backend/src/utils/session-user.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sessionBelongsToUser } from './session-user.js';
+
+const userId = 42;
+const email = 'victim@example.com';
+
+test('matches credential sessions by userId', () => {
+  assert.equal(sessionBelongsToUser({ userId: 42 }, userId, email), true);
+  assert.equal(sessionBelongsToUser({ userId: '42' }, userId, email), true);
+  assert.equal(sessionBelongsToUser({ userId: 7 }, userId, email), false);
+});
+
+test('matches credential sessions by session.user id or email', () => {
+  assert.equal(
+    sessionBelongsToUser({ user: { id: 42, email: 'other@example.com' } }, userId, email),
+    true
+  );
+  assert.equal(
+    sessionBelongsToUser({ user: { id: 7, email: 'Victim@example.com' } }, userId, email),
+    true
+  );
+  assert.equal(
+    sessionBelongsToUser({ user: { id: 7, email: 'other@example.com' } }, userId, email),
+    false
+  );
+});
+
+test('matches passport sessions by email object (not whole object === userId)', () => {
+  // Broken old matcher: session.passport.user === userId never holds for object form
+  const passportSession = {
+    passport: {
+      user: { id: 'google-profile-abc', email: 'victim@example.com', name: 'V' },
+    },
+  };
+  assert.equal(sessionBelongsToUser(passportSession, userId, email), true);
+  assert.notEqual(passportSession.passport.user as unknown, userId);
+
+  assert.equal(
+    sessionBelongsToUser(
+      { passport: { user: { id: 'google-other', email: 'other@example.com' } } },
+      userId,
+      email
+    ),
+    false
+  );
+});
+
+test('matches legacy bare passport.user numeric id', () => {
+  assert.equal(sessionBelongsToUser({ passport: { user: 42 } }, userId, email), true);
+  assert.equal(sessionBelongsToUser({ passport: { user: '42' } }, userId, email), true);
+  // Google profile string ids must not match DB id by coercion of non-numeric strings
+  assert.equal(
+    sessionBelongsToUser({ passport: { user: 'google-profile-abc' } }, userId, email),
+    false
+  );
+});
+
+test('rejects empty or unrelated sessions', () => {
+  assert.equal(sessionBelongsToUser(null, userId, email), false);
+  assert.equal(sessionBelongsToUser({}, userId, email), false);
+  assert.equal(sessionBelongsToUser({ passport: {} }, userId, email), false);
+});

--- a/backend/src/utils/session-user.ts
+++ b/backend/src/utils/session-user.ts
@@ -1,0 +1,83 @@
+/**
+ * Session ownership helpers for auth wipe / content-path checks.
+ * Credential logins store session.userId (DB numeric id).
+ * Passport (Google OAuth) stores session.passport.user as
+ * { id: googleProfileId, email, name, picture } — never the DB id alone.
+ */
+
+/**
+ * True if a store session blob belongs to the given user id/email.
+ * Used when deleting a user to destroy their open sessions.
+ */
+export function sessionBelongsToUser(
+  session: any,
+  userId: number,
+  email: string
+): boolean {
+  if (!session || !Number.isFinite(userId)) {
+    return false;
+  }
+
+  const normalizedEmail = typeof email === 'string' ? email.toLowerCase() : '';
+
+  // Credential sessions
+  if (session.userId != null && Number(session.userId) === userId) {
+    return true;
+  }
+
+  if (session.user) {
+    if (session.user.id != null && Number(session.user.id) === userId) {
+      return true;
+    }
+    if (
+      normalizedEmail &&
+      typeof session.user.email === 'string' &&
+      session.user.email.toLowerCase() === normalizedEmail
+    ) {
+      return true;
+    }
+  }
+
+  // Passport sessions
+  const passportUser = session.passport?.user;
+  if (passportUser == null) {
+    return false;
+  }
+
+  // Object form (current Passport serializeUser stores full user object)
+  if (typeof passportUser === 'object') {
+    if (
+      normalizedEmail &&
+      typeof passportUser.email === 'string' &&
+      passportUser.email.toLowerCase() === normalizedEmail
+    ) {
+      return true;
+    }
+    // Numeric id only if it is the DB id (credential-style), not a Google profile string
+    if (typeof passportUser.id === 'number' && passportUser.id === userId) {
+      return true;
+    }
+    if (
+      typeof passportUser.id === 'string' &&
+      /^\d+$/.test(passportUser.id) &&
+      Number(passportUser.id) === userId
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  // Legacy: bare id serialized as passport.user
+  if (typeof passportUser === 'number' && passportUser === userId) {
+    return true;
+  }
+  if (
+    typeof passportUser === 'string' &&
+    /^\d+$/.test(passportUser) &&
+    Number(passportUser) === userId
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
# Ticket 3254 — deleted-user sessions still open private albums

## Finding
Confirmed as filed. `DELETE /api/auth-extended/users/:userId` wiped sessions with `session.passport.user === userId` only. Passport stores an object `{ id: googleProfileId, email, ... }`; credential logins set `session.userId` and never hit that branch. Content paths used a shallow session presence check with no DB re-validation.

## Changes
1. **`backend/src/utils/session-user.ts`** — pure `sessionBelongsToUser(session, userId, email)` matcher for credential (`userId` / `user`) and Passport (email on `passport.user` object, plus legacy bare numeric id).
2. **`backend/src/routes/auth-extended.ts`** — delete-user wipe uses that matcher with deleted id + email.
3. **`backend/src/utils/album-access.ts`** — `isRequestAuthenticated` reloads user via `getUserById` / `getUserByEmail` and requires `is_active` (same idea as `requireAuth`).
4. **`backend/src/routes/albums.ts`**, **`backend/src/routes/video.ts`** — list/stream access use hardened `isRequestAuthenticated` instead of the shallow check.
5. **Tests** — session matcher unit tests; album-access fixtures create users table + active/inactive/deleted users; asserts deleted/inactive sessions denied on private albums.

## Verification
```
cd backend && npm test
# 15/15 pass (album-access + session-user)
```

## Files
- `backend/src/utils/session-user.ts` (new)
- `backend/src/utils/session-user.test.ts` (new)
- `backend/src/utils/album-access.ts`
- `backend/src/utils/album-access.test.ts`
- `backend/src/routes/auth-extended.ts`
- `backend/src/routes/albums.ts`
- `backend/src/routes/video.ts`
- `backend/package.json` (test script includes session-user tests)

Implements Orchestrator ticket #3254.