### PR TITLE
[bug-scan] Folder delete with deleteAlbums skips videoDir HLS trees

### DIFF
--- a/backend/src/routes/folder-management.ts
+++ b/backend/src/routes/folder-management.ts
@@ -174,6 +174,7 @@ router.delete("/:folder", requireManager, async (req: Request, res: Response): P
       
       const photosDir = req.app.get('photosDir');
       const optimizedDir = req.app.get('optimizedDir');
+      const videoDir = req.app.get('videoDir');
       
       for (const album of albumsInFolder) {
         try {
@@ -191,6 +192,15 @@ router.delete("/:folder", requireManager, async (req: Request, res: Response): P
               fs.rmSync(optimizedPath, { recursive: true, force: true });
             }
           });
+
+          // Delete from video directory (HLS trees / original.mp4) if configured
+          if (videoDir) {
+            const videoPath = path.join(videoDir, album.name);
+            if (fs.existsSync(videoPath)) {
+              fs.rmSync(videoPath, { recursive: true, force: true });
+              info(`[FolderManagement] Deleted video directory: ${album.name}`);
+            }
+          }
           
           // Cancel share link expiry timers before deleting
           try {


### PR DESCRIPTION
# Summary — ticket 3339

## What changed

Folder delete with `deleteAlbums=true` left HLS / `original.mp4` trees under `videoDir/<album>` while album DELETE already removed them. That leaked disk and could collide on album name reuse.

## Fix

In `backend/src/routes/folder-management.ts`, when cascading album deletes, also `rmSync` `path.join(videoDir, album.name)` when `videoDir` is configured — same pattern as `album-management.ts` DELETE `/:album`.

## Files

- `backend/src/routes/folder-management.ts` — read `videoDir` once with photos/optimized dirs; per album, recursive force remove if present; log delete.

## Verification

- `npm ci --cache .npm-cache` (global npm cache was root-owned; used worktree cache)
- `npm test --prefix backend` — 22 pass, 0 fail
- `npm run build --prefix backend` (`tsc`) — clean

No new unit test: delete path is embedded in the route handler; fix mirrors the existing album-management block one-for-one.

Implements Orchestrator ticket #3339.