### PR TITLE
[bug-scan] Concurrent uploads sharing originalname corrupt the same temp path

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -11,6 +11,7 @@ import { execFile, spawn } from "child_process";
 import { promisify } from "util";
 import multer from "multer";
 import os from "os";
+import crypto from "crypto";
 import sharp from "sharp";
 import { csrfProtection } from "../security.js";
 import { requireAuth, requireAdmin, requireManager } from '../auth/middleware.js';
@@ -394,8 +395,10 @@ const upload = multer({
       cb(null, os.tmpdir());
     },
     filename: (req, file, cb) => {
-      // Keep original filename
-      cb(null, file.originalname);
+      // Unique temp name so concurrent same-originalname uploads never share a path.
+      // Album destination still uses file.originalname via sanitizePhotoName.
+      const ext = path.extname(file.originalname);
+      cb(null, `${crypto.randomUUID()}${ext}`);
     }
   }),
   limits: {


### PR DESCRIPTION
# Summary — ticket #3333

## What changed

Multer `diskStorage` for album photo/video (and video thumbnail) uploads wrote every temp file as `os.tmpdir()/file.originalname`. Concurrent uploads sharing a camera name (e.g. `IMG_0001.jpg`) truncated/interleaved the same path.

Filename callback now uses `crypto.randomUUID()` plus the original extension. Destination album names still come from `sanitizePhotoName(file.originalname)`; only the temp path is unique.

## Files

- `backend/src/routes/album-management.ts` — import `crypto`; unique temp filename in multer config

## Verification

- `cd backend && npx tsc --noEmit` — clean
- `cd backend && npm test` — 22 pass, 0 fail
- Confirmed handlers use `file.path` for temp I/O and `file.originalname` for album naming (no further call-site changes needed)

## Install note

`npm ci` needed local cache (`.npm-cache`, already gitignored) due to host `~/.npm` EACCES.

Implements Orchestrator ticket #3333.