### PR TITLE
[bug-scan] Video-optimization cleanup setTimeout nulls a subsequent job

### DIFF
--- a/backend/src/routes/video-optimization.ts
+++ b/backend/src/routes/video-optimization.ts
@@ -218,10 +218,13 @@ router.post('/regenerate', requireManager, (req, res) => {
         });
       }
       
-      // Clean up after 5 minutes
+      // Clean up after 5 minutes — only clear if no newer job replaced us
+      const jobRef = runningVideoOptimizationJob;
       setTimeout(() => {
-        info('[VideoOptimization] Cleaning up completed job');
-        runningVideoOptimizationJob = null;
+        if (runningVideoOptimizationJob === jobRef) {
+          info('[VideoOptimization] Cleaning up completed job');
+          runningVideoOptimizationJob = null;
+        }
       }, 5 * 60 * 1000);
     }
   });
@@ -400,10 +403,13 @@ router.post('/reprocess', requireManager, (req, res) => {
         });
       }
       
-      // Clean up after 5 minutes
+      // Clean up after 5 minutes — only clear if no newer job replaced us
+      const jobRef = runningVideoOptimizationJob;
       setTimeout(() => {
-        info('[VideoReprocessing] Cleaning up completed job');
-        runningVideoOptimizationJob = null;
+        if (runningVideoOptimizationJob === jobRef) {
+          info('[VideoReprocessing] Cleaning up completed job');
+          runningVideoOptimizationJob = null;
+        }
       }, 5 * 60 * 1000);
     }
   });


### PR DESCRIPTION
# Summary — ticket 3336

## What / why

Video optimization cleanup timers always set `runningVideoOptimizationJob = null` after 5 minutes with no job identity check. If job A finished and job B started within that window, A's timer cleared B's tracking object while B was still running — stop/status/reconnect saw no job.

Both cleanup sites now capture `jobRef` at schedule time and only null the global when it still points at that same job.

## Files

- `backend/src/routes/video-optimization.ts` — playlist regeneration close path (~221) and reprocess close path (~400)

## Verification

- `npx tsc --noEmit` (backend) — clean
- `npm test` (backend) — 22 pass, 0 fail
- Confirmed both unguarded `setTimeout` sites now identity-check before clear

Implements Orchestrator ticket #3336.