### PR TITLE
[bug-scan] AI-titles cleanup setTimeout nulls a later job's tracking object

### DIFF
--- a/backend/src/routes/ai-titles.ts
+++ b/backend/src/routes/ai-titles.ts
@@ -522,9 +522,13 @@ router.post('/generate', requireManager, (req, res) => {
         });
       }
       
-      // Clean up after 5 minutes
+      // Clean up after 5 minutes — only if this job is still the tracked one
+      // (a later POST /generate may have replaced runningJobs.aiTitles)
+      const jobRef = runningJobs.aiTitles;
       setTimeout(() => {
-        runningJobs.aiTitles = null;
+        if (runningJobs.aiTitles === jobRef) {
+          runningJobs.aiTitles = null;
+        }
       }, 5 * 60 * 1000);
     }
   });


### PR DESCRIPTION
# Summary — ticket 3335

## What changed

Fixed a race in AI-titles job cleanup: when a job completes, a 5-minute `setTimeout` used to always set `runningJobs.aiTitles = null`. If job A finished and job B had already taken the slot, A's timer would orphan B (break SSE reconnect, `/status`, and stop).

Fix: capture `jobRef` at schedule time and only clear when `runningJobs.aiTitles === jobRef`.

## Files

- `backend/src/routes/ai-titles.ts` — guarded cleanup in `child.on('close')`

## Verification

- Bug present before fix at lines 525–528 (unconditional null).
- `npx tsc --noEmit -p backend/tsconfig.json` — clean (after `npm ci` with temp npm cache).
- `npm test` (backend) — 22/22 pass.
- No route-level unit tests for ai-titles; change is reference-equality guard only.

## Notes

Same unconditional-timeout pattern exists in `image-optimization.ts` and `video-optimization.ts` — left alone (out of ticket scope).

Implements Orchestrator ticket #3335.