### PR TITLE
[bug-scan] Video thumbnail upload error path leaves multer temp file

### DIFF
--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1715,6 +1715,8 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
     const { albumName, filename } = req.params;
     
     if (!albumName || !filename) {
+      // Multer may already have written the file to os.tmpdir()
+      unlinkTempUpload(req.file?.path);
       res.status(400).json({ error: 'Album name and filename are required' });
       return;
     }
@@ -1750,7 +1752,7 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
       .toFile(modalPath);
     
     // Clean up temporary file
-    fs.unlinkSync(req.file.path);
+    unlinkTempUpload(req.file.path);
     
     info(`[VideoThumbnail] Uploaded custom thumbnail for ${albumName}/${filename}`);
     
@@ -1768,6 +1770,8 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
       message: 'Custom thumbnail uploaded successfully'
     });
   } catch (err) {
+    // Always remove multer diskStorage temp on sharp/IO failure
+    unlinkTempUpload(req.file?.path);
     error('[VideoThumbnail] Failed to upload custom thumbnail:', err);
     res.status(500).json({ error: 'Failed to upload custom thumbnail' });
   }


### PR DESCRIPTION
# Summary — ticket 3338

## What changed

Video custom-thumbnail upload (`POST /api/albums/:albumName/video/:filename/upload-thumbnail`) left multer `diskStorage` temp files under `os.tmpdir()` when sharp/IO failed (or on early 400 after multer had already written the file). Success unlinked; catch did not.

## Fix

In `backend/src/routes/album-management.ts`:

- Early return when album/filename missing: `unlinkTempUpload(req.file?.path)` (same pattern as photo upload).
- Success path: `unlinkTempUpload(req.file.path)` instead of bare `fs.unlinkSync`.
- Catch: `unlinkTempUpload(req.file?.path)` before 500 response.

Reuses existing `unlinkTempUpload` helper (best-effort, ignores missing path).

## Files

- `backend/src/routes/album-management.ts` — only source change

## Verification

- `npx tsc --noEmit` (backend): clean
- `npm test` (backend): 12 pass / 10 fail — failures are pre-existing in `album-access.test.ts` / session helpers (DB/env), unrelated to this route
- Install: `npm ci --ignore-scripts --cache .npm-cache` (host npm cache EACCES)

## Scope

Minimal resource-leak fix only. No PR URL from implementer — worker publishes.

Implements Orchestrator ticket #3338.