### PR TITLE
[bug-scan] Deleting a video leaves HLS assets playable and .jpg thumbs behind

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/media-disk-cleanup.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -36,6 +36,7 @@ import {
   renameAlbum
 } from "../database.js";
 import { processVideo, VideoProcessingProgress } from "../utils/video-processor.js";
+import { removeMediaDiskAssets } from "../utils/media-disk-cleanup.js";
 import { invalidateAlbumCache } from "./albums.js";
 import { generateStaticJSONFiles } from "./static-json.js";
 import { generateHomepageHTML } from "./homepage-html.js";
@@ -812,6 +813,7 @@ router.delete("/:album/photos/:photo", requireManager, async (req: Request, res:
 
     const photosDir = req.app.get("photosDir");
     const optimizedDir = req.app.get("optimizedDir");
+    const videoDir = req.app.get("videoDir") as string | undefined;
     
     const photoPath = path.join(photosDir, sanitizedAlbum, sanitizedPhoto);
     
@@ -820,16 +822,20 @@ router.delete("/:album/photos/:photo", requireManager, async (req: Request, res:
       return;
     }
 
-    // Delete from photos directory
-    fs.unlinkSync(photoPath);
-
-    // Delete from optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
-      const optimizedPath = path.join(optimizedDir, dir, sanitizedAlbum, sanitizedPhoto);
-      if (fs.existsSync(optimizedPath)) {
-        fs.unlinkSync(optimizedPath);
-      }
+    // Original + optimized same-name; for videos also HLS tree and .jpg posters
+    const diskCleanup = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album: sanitizedAlbum,
+      filename: sanitizedPhoto,
     });
+    if (diskCleanup.hlsRemoved) {
+      info(`[AlbumManagement] Removed HLS assets for video: ${sanitizedAlbum}/${sanitizedPhoto}`);
+    }
+    if (diskCleanup.posterRemoved.length > 0) {
+      info(`[AlbumManagement] Removed video posters: ${diskCleanup.posterRemoved.join(', ')}`);
+    }
 
     // Delete metadata from database
     const deleted = deleteImageMetadata(sanitizedAlbum, sanitizedPhoto);

--- a/backend/src/utils/media-disk-cleanup.test.ts
+++ b/backend/src/utils/media-disk-cleanup.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  isVideoFilename,
+  removeMediaDiskAssets,
+  videoPosterFilename,
+} from "./media-disk-cleanup.js";
+
+function touch(filePath: string, contents = "x"): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+}
+
+test("isVideoFilename and videoPosterFilename", () => {
+  assert.equal(isVideoFilename("clip.mp4"), true);
+  assert.equal(isVideoFilename("clip.MOV"), true);
+  assert.equal(isVideoFilename("shot.jpg"), false);
+  assert.equal(videoPosterFilename("clip.mp4"), "clip.jpg");
+  assert.equal(videoPosterFilename("my.video.webm"), "my.video.jpg");
+});
+
+test("removeMediaDiskAssets deletes photo original and same-name optimized only", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "galleria-media-cleanup-photo-"));
+  try {
+    const photosDir = path.join(root, "photos");
+    const optimizedDir = path.join(root, "optimized");
+    const videoDir = path.join(root, "video");
+    const album = "Trip";
+    const filename = "sunset.jpg";
+
+    touch(path.join(photosDir, album, filename));
+    for (const dir of ["thumbnail", "modal", "download"]) {
+      touch(path.join(optimizedDir, dir, album, filename));
+    }
+    // unrelated video tree must not be touched
+    touch(path.join(videoDir, album, "other.mp4", "master.m3u8"));
+
+    const result = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album,
+      filename,
+    });
+
+    assert.equal(result.originalDeleted, true);
+    assert.equal(result.hlsRemoved, false);
+    assert.equal(result.posterRemoved.length, 0);
+    assert.equal(existsSync(path.join(photosDir, album, filename)), false);
+    for (const dir of ["thumbnail", "modal", "download"]) {
+      assert.equal(existsSync(path.join(optimizedDir, dir, album, filename)), false);
+    }
+    assert.equal(
+      existsSync(path.join(videoDir, album, "other.mp4", "master.m3u8")),
+      true
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("removeMediaDiskAssets deletes video HLS tree and .jpg posters", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "galleria-media-cleanup-video-"));
+  try {
+    const photosDir = path.join(root, "photos");
+    const optimizedDir = path.join(root, "optimized");
+    const videoDir = path.join(root, "video");
+    const album = "Trip";
+    const filename = "clip.mp4";
+    const poster = "clip.jpg";
+
+    touch(path.join(photosDir, album, filename), "mp4");
+    // processVideo writes posters as basename.jpg, not .mp4
+    touch(path.join(optimizedDir, "thumbnail", album, poster));
+    touch(path.join(optimizedDir, "modal", album, poster));
+    touch(path.join(optimizedDir, "download", album, poster));
+    // HLS tree under videoDir/<album>/<filename>/
+    touch(path.join(videoDir, album, filename, "master.m3u8"), "#EXTM3U");
+    touch(path.join(videoDir, album, filename, "720p", "seg0.ts"), "ts");
+    // sibling video must remain
+    touch(path.join(videoDir, album, "keep.mp4", "master.m3u8"), "#EXTM3U");
+    touch(path.join(photosDir, album, "keep.mp4"), "mp4");
+
+    const result = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album,
+      filename,
+    });
+
+    assert.equal(result.originalDeleted, true);
+    assert.equal(result.hlsRemoved, true);
+    assert.deepEqual(
+      new Set(result.posterRemoved),
+      new Set([
+        "thumbnail/clip.jpg",
+        "modal/clip.jpg",
+        "download/clip.jpg",
+      ])
+    );
+
+    assert.equal(existsSync(path.join(photosDir, album, filename)), false);
+    assert.equal(existsSync(path.join(videoDir, album, filename)), false);
+    for (const dir of ["thumbnail", "modal", "download"]) {
+      assert.equal(existsSync(path.join(optimizedDir, dir, album, poster)), false);
+    }
+    // sibling preserved
+    assert.equal(existsSync(path.join(videoDir, album, "keep.mp4", "master.m3u8")), true);
+    assert.equal(existsSync(path.join(photosDir, album, "keep.mp4")), true);
+    assert.equal(
+      readFileSync(path.join(videoDir, album, "keep.mp4", "master.m3u8"), "utf8"),
+      "#EXTM3U"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("removeMediaDiskAssets is no-op for missing optimized/HLS paths", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "galleria-media-cleanup-missing-"));
+  try {
+    const photosDir = path.join(root, "photos");
+    const optimizedDir = path.join(root, "optimized");
+    const videoDir = path.join(root, "video");
+    const album = "Empty";
+    const filename = "gone.mp4";
+    touch(path.join(photosDir, album, filename));
+
+    const result = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album,
+      filename,
+    });
+
+    assert.equal(result.originalDeleted, true);
+    assert.equal(result.hlsRemoved, false);
+    assert.equal(result.posterRemoved.length, 0);
+    assert.equal(existsSync(path.join(photosDir, album, filename)), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/backend/src/utils/media-disk-cleanup.ts
+++ b/backend/src/utils/media-disk-cleanup.ts
@@ -1,0 +1,100 @@
+/**
+ * On-disk cleanup for album media deleted via the management API.
+ * Videos leave HLS under videoDir and .jpg posters under optimized — not
+ * the same filename as the original .mp4.
+ */
+
+import fs from "fs";
+import path from "path";
+
+const OPTIMIZED_SUBDIRS = ["thumbnail", "modal", "download"] as const;
+
+export function isVideoFilename(filename: string): boolean {
+  return /\.(mp4|mov|avi|mkv|webm)$/i.test(filename);
+}
+
+export function videoPosterFilename(filename: string): string {
+  return filename.replace(/\.[^.]+$/, ".jpg");
+}
+
+export interface MediaDiskCleanupOptions {
+  photosDir: string;
+  optimizedDir: string;
+  /** When set, removes HLS tree videoDir/<album>/<filename>/ for videos */
+  videoDir?: string | null;
+  album: string;
+  filename: string;
+}
+
+export interface MediaDiskCleanupResult {
+  originalDeleted: boolean;
+  optimizedRemoved: string[];
+  hlsRemoved: boolean;
+  posterRemoved: string[];
+}
+
+/**
+ * Unlink the original file, same-name optimized variants, and (for videos)
+ * the HLS directory tree plus basename.jpg poster files.
+ * Throws if the original is missing (caller should 404 first) only when
+ * deleteOriginal is true and the path does not exist — callers may pass
+ * deleteOriginal: false after they already unlinked.
+ */
+export function removeMediaDiskAssets(
+  options: MediaDiskCleanupOptions & { deleteOriginal?: boolean }
+): MediaDiskCleanupResult {
+  const {
+    photosDir,
+    optimizedDir,
+    videoDir,
+    album,
+    filename,
+    deleteOriginal = true,
+  } = options;
+
+  const result: MediaDiskCleanupResult = {
+    originalDeleted: false,
+    optimizedRemoved: [],
+    hlsRemoved: false,
+    posterRemoved: [],
+  };
+
+  if (deleteOriginal) {
+    const photoPath = path.join(photosDir, album, filename);
+    if (fs.existsSync(photoPath)) {
+      fs.unlinkSync(photoPath);
+      result.originalDeleted = true;
+    }
+  }
+
+  for (const dir of OPTIMIZED_SUBDIRS) {
+    const optimizedPath = path.join(optimizedDir, dir, album, filename);
+    if (fs.existsSync(optimizedPath)) {
+      fs.unlinkSync(optimizedPath);
+      result.optimizedRemoved.push(path.join(dir, filename));
+    }
+  }
+
+  if (!isVideoFilename(filename)) {
+    return result;
+  }
+
+  if (videoDir) {
+    const hlsPath = path.join(videoDir, album, filename);
+    if (fs.existsSync(hlsPath)) {
+      fs.rmSync(hlsPath, { recursive: true, force: true });
+      result.hlsRemoved = true;
+    }
+  }
+
+  const posterName = videoPosterFilename(filename);
+  for (const dir of OPTIMIZED_SUBDIRS) {
+    const posterPath = path.join(optimizedDir, dir, album, posterName);
+    if (fs.existsSync(posterPath)) {
+      fs.unlinkSync(posterPath);
+      result.posterRemoved.push(path.join(dir, posterName));
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
# Ticket 3332 — delete video leaves HLS + .jpg thumbs

## What / why

DELETE `/:album/photos/:photo` unlinked the original under `photos/` and optimized files that shared the **exact** same filename. Video processing writes HLS under `videoDir/<album>/<filename>/` and posters as `<basename>.jpg`, so deleted videos still streamed (route only checks album auth + file existence) and poster files leaked disk.

## Changes

- New `backend/src/utils/media-disk-cleanup.ts` — `removeMediaDiskAssets`: original + same-name optimized; for videos also recursive HLS tree + thumbnail/modal/download `.jpg` posters.
- `backend/src/routes/album-management.ts` — photo delete handler uses that helper (passes `videoDir` from app).
- `backend/src/utils/media-disk-cleanup.test.ts` — unit tests for photo vs video cleanup and missing-asset no-ops.
- `backend/package.json` — include new test file in `npm test`.

## Verification

- `npx tsc --noEmit -p backend/tsconfig.json` — clean
- `cd backend && npm test` — 26/26 pass (after `npm rebuild better-sqlite3`; install used `npm ci --ignore-scripts --cache .npm-cache` due to host npm cache EACCES)

## Notes

- Photo delete path unchanged in behavior for stills.
- Album-level delete already removed full `videoDir/<album>`; this is the per-file gap only.

Implements Orchestrator ticket #3332.