### PR TITLE
[bug-scan] Album rename has no FS rollback when a mid-sequence rename throws

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -42,6 +42,7 @@ import { generateHomepageHTML } from "./homepage-html.js";
 import { broadcastOptimizationUpdate, queueOptimizationJob } from "./optimization-stream.js";
 import OpenAI from "openai";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
+import { rollbackRenamedPaths, type RenamedPath } from '../utils/rename-rollback.js';
 
 const router = Router();
 const execFileAsync = promisify(execFile);
@@ -575,11 +576,16 @@ router.post("/", requireManager, async (req: Request, res: Response): Promise<vo
 });
 
 /**
- * Rename an album (FS first, then DB; roll back FS if DB fails).
+ * Rename an album (FS first, then DB; roll back FS if DB fails or a later FS rename throws).
  * Shared by PUT and PATCH so the live API surface cannot diverge into a
  * DB-first path with no rollback (see ticket #2746).
  */
 async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
+  // Track successful renames so mid-sequence FS failures can reverse prior moves
+  // (photos/ can succeed while optimized/ or video/ throws — see ticket #3337).
+  const renamedPaths: RenamedPath[] = [];
+  let dbUpdated = false;
+
   try {
     const { album } = req.params;
     const { newName } = req.body;
@@ -626,26 +632,27 @@ async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
     
     // Rename photos directory first — if this fails, DB is untouched
     fs.renameSync(oldAlbumPath, newAlbumPath);
+    renamedPaths.push({ from: oldAlbumPath, to: newAlbumPath });
     info(`[AlbumManagement] Renamed photos directory: ${sanitizedOldName} → ${sanitizedNewName}`);
     
     // Rename optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
+    for (const dir of ['thumbnail', 'modal', 'download'] as const) {
       const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
       const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
       if (fs.existsSync(oldOptimizedPath)) {
         fs.renameSync(oldOptimizedPath, newOptimizedPath);
+        renamedPaths.push({ from: oldOptimizedPath, to: newOptimizedPath });
       }
-    });
+    }
     
     // Rename video directory if it exists
     const videoDir = req.app.get("videoDir");
-    let videoRenamed = false;
     if (videoDir) {
       const oldVideoPath = path.join(videoDir, sanitizedOldName);
       const newVideoPath = path.join(videoDir, sanitizedNewName);
       if (fs.existsSync(oldVideoPath)) {
         fs.renameSync(oldVideoPath, newVideoPath);
-        videoRenamed = true;
+        renamedPaths.push({ from: oldVideoPath, to: newVideoPath });
         info(`[AlbumManagement] Renamed video directory: ${sanitizedOldName} → ${sanitizedNewName}`);
       }
     }
@@ -653,26 +660,11 @@ async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
     // Update database after FS; roll FS back if DB fails
     const success = renameAlbum(sanitizedOldName, sanitizedNewName);
     if (!success) {
-      // Rollback filesystem changes
-      fs.renameSync(newAlbumPath, oldAlbumPath);
-      ['thumbnail', 'modal', 'download'].forEach(dir => {
-        const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
-        const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
-        if (fs.existsSync(newOptimizedPath)) {
-          fs.renameSync(newOptimizedPath, oldOptimizedPath);
-        }
-      });
-      // Rollback video directory if it was renamed
-      if (videoRenamed && videoDir) {
-        const oldVideoPath = path.join(videoDir, sanitizedOldName);
-        const newVideoPath = path.join(videoDir, sanitizedNewName);
-        if (fs.existsSync(newVideoPath)) {
-          fs.renameSync(newVideoPath, oldVideoPath);
-        }
-      }
+      rollbackRenamedPaths(renamedPaths);
       res.status(500).json({ errorCode: 'DATABASE_UPDATE_FAILED', error: 'Failed to update database' });
       return;
     }
+    dbUpdated = true;
     
     info(`[AlbumManagement] Renamed album in database: ${sanitizedOldName} → ${sanitizedNewName}`);
     
@@ -686,6 +678,11 @@ async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
     
     res.json({ success: true, newName: sanitizedNewName });
   } catch (err) {
+    // Only reverse FS when DB still has the old name — never after a successful renameAlbum.
+    if (!dbUpdated && renamedPaths.length > 0) {
+      warn('[AlbumManagement] Rolling back FS renames after mid-sequence failure');
+      rollbackRenamedPaths(renamedPaths);
+    }
     error('[AlbumManagement] Failed to rename album:', err);
     res.status(500).json({ errorCode: 'RENAME_FAILED', error: 'Failed to rename album' });
   }

--- a/backend/src/utils/rename-rollback.test.ts
+++ b/backend/src/utils/rename-rollback.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { rollbackRenamedPaths, type RenamedPath } from './rename-rollback.js';
+
+test('rollbackRenamedPaths reverses renames LIFO', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'galleria-rename-rollback-'));
+  try {
+    const photosOld = path.join(root, 'photos', 'old-album');
+    const photosNew = path.join(root, 'photos', 'new-album');
+    const thumbOld = path.join(root, 'optimized', 'thumbnail', 'old-album');
+    const thumbNew = path.join(root, 'optimized', 'thumbnail', 'new-album');
+    const videoOld = path.join(root, 'video', 'old-album');
+    const videoNew = path.join(root, 'video', 'new-album');
+
+    mkdirSync(photosNew, { recursive: true });
+    writeFileSync(path.join(photosNew, 'a.jpg'), 'x');
+    mkdirSync(thumbNew, { recursive: true });
+    writeFileSync(path.join(thumbNew, 'a.jpg'), 't');
+    mkdirSync(videoNew, { recursive: true });
+    writeFileSync(path.join(videoNew, 'a.mp4'), 'v');
+
+    const renamed: RenamedPath[] = [
+      { from: photosOld, to: photosNew },
+      { from: thumbOld, to: thumbNew },
+      { from: videoOld, to: videoNew },
+    ];
+
+    rollbackRenamedPaths(renamed);
+
+    assert.equal(existsSync(photosOld), true);
+    assert.equal(existsSync(photosNew), false);
+    assert.equal(existsSync(thumbOld), true);
+    assert.equal(existsSync(thumbNew), false);
+    assert.equal(existsSync(videoOld), true);
+    assert.equal(existsSync(videoNew), false);
+    assert.equal(existsSync(path.join(photosOld, 'a.jpg')), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rollbackRenamedPaths is a no-op for empty list', () => {
+  rollbackRenamedPaths([]);
+});
+
+test('rollbackRenamedPaths skips missing destinations', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'galleria-rename-rollback-missing-'));
+  try {
+    const from = path.join(root, 'old');
+    const to = path.join(root, 'new');
+    // Neither path exists — must not throw
+    rollbackRenamedPaths([{ from, to }]);
+    assert.equal(existsSync(from), false);
+    assert.equal(existsSync(to), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rollbackRenamedPaths restores photos when optimized rename would have failed mid-sequence', () => {
+  // Simulates ticket #3337: photos/ already at new name; optimized half-done;
+  // catch rolls everything tracked back to old names.
+  const root = mkdtempSync(path.join(tmpdir(), 'galleria-rename-mid-fail-'));
+  try {
+    const photosOld = path.join(root, 'photos', 'summer');
+    const photosNew = path.join(root, 'photos', 'summer-2024');
+    const thumbOld = path.join(root, 'optimized', 'thumbnail', 'summer');
+    const thumbNew = path.join(root, 'optimized', 'thumbnail', 'summer-2024');
+    // modal never renamed (failure before it) — not in list
+    const modalOld = path.join(root, 'optimized', 'modal', 'summer');
+
+    mkdirSync(photosNew, { recursive: true });
+    writeFileSync(path.join(photosNew, '1.jpg'), 'photo');
+    mkdirSync(thumbNew, { recursive: true });
+    writeFileSync(path.join(thumbNew, '1.jpg'), 'thumb');
+    mkdirSync(modalOld, { recursive: true });
+    writeFileSync(path.join(modalOld, '1.jpg'), 'modal');
+
+    const renamed: RenamedPath[] = [
+      { from: photosOld, to: photosNew },
+      { from: thumbOld, to: thumbNew },
+      // modal rename never succeeded — not tracked
+    ];
+
+    rollbackRenamedPaths(renamed);
+
+    assert.equal(existsSync(photosOld), true, 'photos restored to old name');
+    assert.equal(existsSync(photosNew), false);
+    assert.equal(existsSync(thumbOld), true, 'thumbnail restored to old name');
+    assert.equal(existsSync(thumbNew), false);
+    assert.equal(existsSync(modalOld), true, 'unmoved modal stays under old name');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/backend/src/utils/rename-rollback.ts
+++ b/backend/src/utils/rename-rollback.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracked filesystem renames with LIFO rollback.
+ * Used by album rename so a mid-sequence fs failure can reverse prior moves.
+ */
+
+import fs from 'fs';
+import { error } from './logger.js';
+
+/** One successful FS rename (old path → new path). */
+export type RenamedPath = { from: string; to: string };
+
+/**
+ * Reverse successful renames in reverse order (best-effort).
+ * Safe to call with an empty list. Logs and continues if a reverse fails.
+ */
+export function rollbackRenamedPaths(renamedPaths: RenamedPath[]): void {
+  for (let i = renamedPaths.length - 1; i >= 0; i--) {
+    const { from, to } = renamedPaths[i];
+    try {
+      if (fs.existsSync(to)) {
+        fs.renameSync(to, from);
+      }
+    } catch (rollbackErr) {
+      error(`[AlbumManagement] Failed to roll back rename ${to} → ${from}:`, rollbackErr);
+    }
+  }
+}


### PR DESCRIPTION
# Summary — ticket 3337

## What changed

Album rename (`handleRenameAlbum` in `backend/src/routes/album-management.ts`) now tracks every successful filesystem rename (`photos/`, `optimized/{thumbnail,modal,download}/`, `video/`) as `{ from, to }` pairs. If a later `fs.renameSync` throws, or `renameAlbum()` returns false, those moves are reversed LIFO via `rollbackRenamedPaths`. The outer catch no longer leaves photos under the new path while the DB still has the old name.

Rollback is skipped after a successful DB update so a post-commit failure (cache/static JSON) cannot desync FS back away from the new name.

Helper lives in `backend/src/utils/rename-rollback.ts` so unit tests do not load the full route module.

## Files

- `backend/src/routes/album-management.ts` — track renames; catch + DB-fail rollback
- `backend/src/utils/rename-rollback.ts` — `rollbackRenamedPaths` helper
- `backend/src/utils/rename-rollback.test.ts` — LIFO reverse + mid-sequence scenario
- `backend/package.json` — include new test file in `npm test`

## Verification

- `npm ci --cache /tmp/npm-cache-galleria-3337` (default cache was EACCES)
- `cd backend && npm test` — 26 pass, 0 fail (includes 4 new rename-rollback tests)

Implements Orchestrator ticket #3337.