### PR TITLE
[bug-scan] rotateVideo/generateHLS/extractThumbnail hang if ffmpeg spawn fails

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/video-processor.spawn-error.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/utils/video-processor.spawn-error.test.ts
+++ b/backend/src/utils/video-processor.spawn-error.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Ensures ffmpeg spawn failures reject instead of hanging the Promise.
+ * Trigger: empty PATH so spawn emits ENOENT (same class as missing ffmpeg).
+ */
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { extractThumbnail, generateHLS, rotateVideo } from './video-processor.js';
+
+async function withEmptyPath<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = prev;
+    }
+  }
+}
+
+test('extractThumbnail rejects when ffmpeg spawn fails', async () => {
+  await withEmptyPath(async () => {
+    await assert.rejects(
+      () => extractThumbnail('/tmp/galleria-missing.mp4', '/tmp/galleria-thumb.jpg', 200),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /ffmpeg spawn failed/i);
+        return true;
+      }
+    );
+  });
+});
+
+test('rotateVideo rejects when ffmpeg spawn fails', async () => {
+  await withEmptyPath(async () => {
+    await assert.rejects(
+      () =>
+        rotateVideo(
+          '/tmp/galleria-missing.mp4',
+          '/tmp/galleria-rotated.mp4',
+          { width: 1920, height: 1080, duration: 10, rotation: 90 }
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /ffmpeg spawn failed/i);
+        return true;
+      }
+    );
+  });
+});
+
+test('generateHLS rejects when ffmpeg spawn fails', async () => {
+  await withEmptyPath(async () => {
+    const outDir = path.join('/tmp', `galleria-hls-${process.pid}`);
+    await assert.rejects(
+      () =>
+        generateHLS(
+          '/tmp/galleria-missing.mp4',
+          outDir,
+          { name: '720p', height: 720, videoBitrate: '2500k', audioBitrate: '128k' },
+          4,
+          false
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /ffmpeg spawn failed/i);
+        return true;
+      }
+    );
+  });
+});

--- a/backend/src/utils/video-processor.ts
+++ b/backend/src/utils/video-processor.ts
@@ -253,6 +253,11 @@ export async function rotateVideo(
       }
     });
 
+    // Reject on spawn failure (e.g. ffmpeg missing / ENOENT) so callers do not hang
+    ffmpeg.on('error', (err) => {
+      reject(new Error(`ffmpeg spawn failed: ${err.message}`));
+    });
+
     ffmpeg.on('close', (code) => {
       if (code !== 0) {
         error('[VideoProcessor] Rotation failed:', stderr);
@@ -474,6 +479,11 @@ export async function generateHLS(
       }
     });
 
+    // Reject on spawn failure (e.g. ffmpeg missing / ENOENT) so callers do not hang
+    ffmpeg.on('error', (err) => {
+      reject(new Error(`ffmpeg spawn failed: ${err.message}`));
+    });
+
     ffmpeg.on('close', (code) => {
       if (code !== 0) {
         error(`[VideoProcessor] HLS generation failed for ${resolution.name}:`, stderr);
@@ -513,6 +523,11 @@ export async function extractThumbnail(
     ffmpeg.stderr.on('data', (data) => {
       stderr += data.toString();
       if (onProgress) onProgress(50); // Simple progress indication
+    });
+
+    // Reject on spawn failure (e.g. ffmpeg missing / ENOENT) so callers do not hang
+    ffmpeg.on('error', (err) => {
+      reject(new Error(`ffmpeg spawn failed: ${err.message}`));
     });
 
     ffmpeg.on('close', (code) => {


### PR DESCRIPTION
# Summary — ticket 3334

## What changed

`rotateVideo`, `generateHLS`, and `extractThumbnail` in `backend/src/utils/video-processor.ts` only listened for ffmpeg `close`. On spawn failure (ENOENT / missing ffmpeg), the Promise never settled, so `processVideo`'s free-running path never reported a terminal error.

Added `ffmpeg.on('error', (err) => reject(...))` on each of those three spawns — same pattern as `getVideoMetadata` / ffprobe.

## Files

- `backend/src/utils/video-processor.ts` — three spawn `error` handlers
- `backend/src/utils/video-processor.spawn-error.test.ts` — PATH-empty ENOENT coverage for all three
- `backend/package.json` — include new test in `npm test`

## Verification

- `cd backend && npm test` — 25/25 pass (incl. 3 new spawn-error tests)
- `cd backend && npx tsc --noEmit` — clean

Implements Orchestrator ticket #3334.