### PR TITLE
Batch merge #395: #3339, #3336, #3333, #3335, #3337, #3338, #3334, #3332

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/video-processor.spawn-error.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/media-disk-cleanup.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/ai-titles.ts
+++ b/backend/src/routes/ai-titles.ts
@@ -522,9 +522,13 @@ router.post('/generate', requireManager, (req, res) => {
         });
       }
       
-      // Clean up after 5 minutes
+      // Clean up after 5 minutes — only if this job is still the tracked one
+      // (a later POST /generate may have replaced runningJobs.aiTitles)
+      const jobRef = runningJobs.aiTitles;
       setTimeout(() => {
-        runningJobs.aiTitles = null;
+        if (runningJobs.aiTitles === jobRef) {
+          runningJobs.aiTitles = null;
+        }
       }, 5 * 60 * 1000);
     }
   });

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1715,6 +1715,8 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
     const { albumName, filename } = req.params;
     
     if (!albumName || !filename) {
+      // Multer may already have written the file to os.tmpdir()
+      unlinkTempUpload(req.file?.path);
       res.status(400).json({ error: 'Album name and filename are required' });
       return;
     }
@@ -1750,7 +1752,7 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
       .toFile(modalPath);
     
     // Clean up temporary file
-    fs.unlinkSync(req.file.path);
+    unlinkTempUpload(req.file.path);
     
     info(`[VideoThumbnail] Uploaded custom thumbnail for ${albumName}/${filename}`);
     
@@ -1768,6 +1770,8 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
       message: 'Custom thumbnail uploaded successfully'
     });
   } catch (err) {
+    // Always remove multer diskStorage temp on sharp/IO failure
+    unlinkTempUpload(req.file?.path);
     error('[VideoThumbnail] Failed to upload custom thumbnail:', err);
     res.status(500).json({ error: 'Failed to upload custom thumbnail' });
   }

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -36,6 +36,7 @@ import {
   renameAlbum
 } from "../database.js";
 import { processVideo, VideoProcessingProgress } from "../utils/video-processor.js";
+import { removeMediaDiskAssets } from "../utils/media-disk-cleanup.js";
 import { invalidateAlbumCache } from "./albums.js";
 import { generateStaticJSONFiles } from "./static-json.js";
 import { generateHomepageHTML } from "./homepage-html.js";
@@ -812,6 +813,7 @@ router.delete("/:album/photos/:photo", requireManager, async (req: Request, res:
 
     const photosDir = req.app.get("photosDir");
     const optimizedDir = req.app.get("optimizedDir");
+    const videoDir = req.app.get("videoDir") as string | undefined;
     
     const photoPath = path.join(photosDir, sanitizedAlbum, sanitizedPhoto);
     
@@ -820,16 +822,20 @@ router.delete("/:album/photos/:photo", requireManager, async (req: Request, res:
       return;
     }
 
-    // Delete from photos directory
-    fs.unlinkSync(photoPath);
-
-    // Delete from optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
-      const optimizedPath = path.join(optimizedDir, dir, sanitizedAlbum, sanitizedPhoto);
-      if (fs.existsSync(optimizedPath)) {
-        fs.unlinkSync(optimizedPath);
-      }
+    // Original + optimized same-name; for videos also HLS tree and .jpg posters
+    const diskCleanup = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album: sanitizedAlbum,
+      filename: sanitizedPhoto,
     });
+    if (diskCleanup.hlsRemoved) {
+      info(`[AlbumManagement] Removed HLS assets for video: ${sanitizedAlbum}/${sanitizedPhoto}`);
+    }
+    if (diskCleanup.posterRemoved.length > 0) {
+      info(`[AlbumManagement] Removed video posters: ${diskCleanup.posterRemoved.join(', ')}`);
+    }
 
     // Delete metadata from database
     const deleted = deleteImageMetadata(sanitizedAlbum, sanitizedPhoto);

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -42,6 +42,7 @@ import { generateHomepageHTML } from "./homepage-html.js";
 import { broadcastOptimizationUpdate, queueOptimizationJob } from "./optimization-stream.js";
 import OpenAI from "openai";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
+import { rollbackRenamedPaths, type RenamedPath } from '../utils/rename-rollback.js';
 
 const router = Router();
 const execFileAsync = promisify(execFile);
@@ -575,11 +576,16 @@ router.post("/", requireManager, async (req: Request, res: Response): Promise<vo
 });
 
 /**
- * Rename an album (FS first, then DB; roll back FS if DB fails).
+ * Rename an album (FS first, then DB; roll back FS if DB fails or a later FS rename throws).
  * Shared by PUT and PATCH so the live API surface cannot diverge into a
  * DB-first path with no rollback (see ticket #2746).
  */
 async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
+  // Track successful renames so mid-sequence FS failures can reverse prior moves
+  // (photos/ can succeed while optimized/ or video/ throws — see ticket #3337).
+  const renamedPaths: RenamedPath[] = [];
+  let dbUpdated = false;
+
   try {
     const { album } = req.params;
     const { newName } = req.body;
@@ -626,26 +632,27 @@ async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
     
     // Rename photos directory first — if this fails, DB is untouched
     fs.renameSync(oldAlbumPath, newAlbumPath);
+    renamedPaths.push({ from: oldAlbumPath, to: newAlbumPath });
     info(`[AlbumManagement] Renamed photos directory: ${sanitizedOldName} → ${sanitizedNewName}`);
     
     // Rename optimized directories
-    ['thumbnail', 'modal', 'download'].forEach(dir => {
+    for (const dir of ['thumbnail', 'modal', 'download'] as const) {
       const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
       const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
       if (fs.existsSync(oldOptimizedPath)) {
         fs.renameSync(oldOptimizedPath, newOptimizedPath);
+        renamedPaths.push({ from: oldOptimizedPath, to: newOptimizedPath });
       }
-    });
+    }
     
     // Rename video directory if it exists
     const videoDir = req.app.get("videoDir");
-    let videoRenamed = false;
     if (videoDir) {
       const oldVideoPath = path.join(videoDir, sanitizedOldName);
       const newVideoPath = path.join(videoDir, sanitizedNewName);
       if (fs.existsSync(oldVideoPath)) {
         fs.renameSync(oldVideoPath, newVideoPath);
-        videoRenamed = true;
+        renamedPaths.push({ from: oldVideoPath, to: newVideoPath });
         info(`[AlbumManagement] Renamed video directory: ${sanitizedOldName} → ${sanitizedNewName}`);
       }
     }
@@ -653,26 +660,11 @@ async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
     // Update database after FS; roll FS back if DB fails
     const success = renameAlbum(sanitizedOldName, sanitizedNewName);
     if (!success) {
-      // Rollback filesystem changes
-      fs.renameSync(newAlbumPath, oldAlbumPath);
-      ['thumbnail', 'modal', 'download'].forEach(dir => {
-        const oldOptimizedPath = path.join(optimizedDir, dir, sanitizedOldName);
-        const newOptimizedPath = path.join(optimizedDir, dir, sanitizedNewName);
-        if (fs.existsSync(newOptimizedPath)) {
-          fs.renameSync(newOptimizedPath, oldOptimizedPath);
-        }
-      });
-      // Rollback video directory if it was renamed
-      if (videoRenamed && videoDir) {
-        const oldVideoPath = path.join(videoDir, sanitizedOldName);
-        const newVideoPath = path.join(videoDir, sanitizedNewName);
-        if (fs.existsSync(newVideoPath)) {
-          fs.renameSync(newVideoPath, oldVideoPath);
-        }
-      }
+      rollbackRenamedPaths(renamedPaths);
       res.status(500).json({ errorCode: 'DATABASE_UPDATE_FAILED', error: 'Failed to update database' });
       return;
     }
+    dbUpdated = true;
     
     info(`[AlbumManagement] Renamed album in database: ${sanitizedOldName} → ${sanitizedNewName}`);
     
@@ -686,6 +678,11 @@ async function handleRenameAlbum(req: Request, res: Response): Promise<void> {
     
     res.json({ success: true, newName: sanitizedNewName });
   } catch (err) {
+    // Only reverse FS when DB still has the old name — never after a successful renameAlbum.
+    if (!dbUpdated && renamedPaths.length > 0) {
+      warn('[AlbumManagement] Rolling back FS renames after mid-sequence failure');
+      rollbackRenamedPaths(renamedPaths);
+    }
     error('[AlbumManagement] Failed to rename album:', err);
     res.status(500).json({ errorCode: 'RENAME_FAILED', error: 'Failed to rename album' });
   }

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -11,6 +11,7 @@ import { execFile, spawn } from "child_process";
 import { promisify } from "util";
 import multer from "multer";
 import os from "os";
+import crypto from "crypto";
 import sharp from "sharp";
 import { csrfProtection } from "../security.js";
 import { requireAuth, requireAdmin, requireManager } from '../auth/middleware.js';
@@ -394,8 +395,10 @@ const upload = multer({
       cb(null, os.tmpdir());
     },
     filename: (req, file, cb) => {
-      // Keep original filename
-      cb(null, file.originalname);
+      // Unique temp name so concurrent same-originalname uploads never share a path.
+      // Album destination still uses file.originalname via sanitizePhotoName.
+      const ext = path.extname(file.originalname);
+      cb(null, `${crypto.randomUUID()}${ext}`);
     }
   }),
   limits: {

--- a/backend/src/routes/folder-management.ts
+++ b/backend/src/routes/folder-management.ts
@@ -174,6 +174,7 @@ router.delete("/:folder", requireManager, async (req: Request, res: Response): P
       
       const photosDir = req.app.get('photosDir');
       const optimizedDir = req.app.get('optimizedDir');
+      const videoDir = req.app.get('videoDir');
       
       for (const album of albumsInFolder) {
         try {
@@ -191,6 +192,15 @@ router.delete("/:folder", requireManager, async (req: Request, res: Response): P
               fs.rmSync(optimizedPath, { recursive: true, force: true });
             }
           });
+
+          // Delete from video directory (HLS trees / original.mp4) if configured
+          if (videoDir) {
+            const videoPath = path.join(videoDir, album.name);
+            if (fs.existsSync(videoPath)) {
+              fs.rmSync(videoPath, { recursive: true, force: true });
+              info(`[FolderManagement] Deleted video directory: ${album.name}`);
+            }
+          }
           
           // Cancel share link expiry timers before deleting
           try {

--- a/backend/src/routes/video-optimization.ts
+++ b/backend/src/routes/video-optimization.ts
@@ -218,10 +218,13 @@ router.post('/regenerate', requireManager, (req, res) => {
         });
       }
       
-      // Clean up after 5 minutes
+      // Clean up after 5 minutes — only clear if no newer job replaced us
+      const jobRef = runningVideoOptimizationJob;
       setTimeout(() => {
-        info('[VideoOptimization] Cleaning up completed job');
-        runningVideoOptimizationJob = null;
+        if (runningVideoOptimizationJob === jobRef) {
+          info('[VideoOptimization] Cleaning up completed job');
+          runningVideoOptimizationJob = null;
+        }
       }, 5 * 60 * 1000);
     }
   });
@@ -400,10 +403,13 @@ router.post('/reprocess', requireManager, (req, res) => {
         });
       }
       
-      // Clean up after 5 minutes
+      // Clean up after 5 minutes — only clear if no newer job replaced us
+      const jobRef = runningVideoOptimizationJob;
       setTimeout(() => {
-        info('[VideoReprocessing] Cleaning up completed job');
-        runningVideoOptimizationJob = null;
+        if (runningVideoOptimizationJob === jobRef) {
+          info('[VideoReprocessing] Cleaning up completed job');
+          runningVideoOptimizationJob = null;
+        }
       }, 5 * 60 * 1000);
     }
   });

--- a/backend/src/utils/media-disk-cleanup.test.ts
+++ b/backend/src/utils/media-disk-cleanup.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  isVideoFilename,
+  removeMediaDiskAssets,
+  videoPosterFilename,
+} from "./media-disk-cleanup.js";
+
+function touch(filePath: string, contents = "x"): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+}
+
+test("isVideoFilename and videoPosterFilename", () => {
+  assert.equal(isVideoFilename("clip.mp4"), true);
+  assert.equal(isVideoFilename("clip.MOV"), true);
+  assert.equal(isVideoFilename("shot.jpg"), false);
+  assert.equal(videoPosterFilename("clip.mp4"), "clip.jpg");
+  assert.equal(videoPosterFilename("my.video.webm"), "my.video.jpg");
+});
+
+test("removeMediaDiskAssets deletes photo original and same-name optimized only", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "galleria-media-cleanup-photo-"));
+  try {
+    const photosDir = path.join(root, "photos");
+    const optimizedDir = path.join(root, "optimized");
+    const videoDir = path.join(root, "video");
+    const album = "Trip";
+    const filename = "sunset.jpg";
+
+    touch(path.join(photosDir, album, filename));
+    for (const dir of ["thumbnail", "modal", "download"]) {
+      touch(path.join(optimizedDir, dir, album, filename));
+    }
+    // unrelated video tree must not be touched
+    touch(path.join(videoDir, album, "other.mp4", "master.m3u8"));
+
+    const result = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album,
+      filename,
+    });
+
+    assert.equal(result.originalDeleted, true);
+    assert.equal(result.hlsRemoved, false);
+    assert.equal(result.posterRemoved.length, 0);
+    assert.equal(existsSync(path.join(photosDir, album, filename)), false);
+    for (const dir of ["thumbnail", "modal", "download"]) {
+      assert.equal(existsSync(path.join(optimizedDir, dir, album, filename)), false);
+    }
+    assert.equal(
+      existsSync(path.join(videoDir, album, "other.mp4", "master.m3u8")),
+      true
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("removeMediaDiskAssets deletes video HLS tree and .jpg posters", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "galleria-media-cleanup-video-"));
+  try {
+    const photosDir = path.join(root, "photos");
+    const optimizedDir = path.join(root, "optimized");
+    const videoDir = path.join(root, "video");
+    const album = "Trip";
+    const filename = "clip.mp4";
+    const poster = "clip.jpg";
+
+    touch(path.join(photosDir, album, filename), "mp4");
+    // processVideo writes posters as basename.jpg, not .mp4
+    touch(path.join(optimizedDir, "thumbnail", album, poster));
+    touch(path.join(optimizedDir, "modal", album, poster));
+    touch(path.join(optimizedDir, "download", album, poster));
+    // HLS tree under videoDir/<album>/<filename>/
+    touch(path.join(videoDir, album, filename, "master.m3u8"), "#EXTM3U");
+    touch(path.join(videoDir, album, filename, "720p", "seg0.ts"), "ts");
+    // sibling video must remain
+    touch(path.join(videoDir, album, "keep.mp4", "master.m3u8"), "#EXTM3U");
+    touch(path.join(photosDir, album, "keep.mp4"), "mp4");
+
+    const result = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album,
+      filename,
+    });
+
+    assert.equal(result.originalDeleted, true);
+    assert.equal(result.hlsRemoved, true);
+    assert.deepEqual(
+      new Set(result.posterRemoved),
+      new Set([
+        "thumbnail/clip.jpg",
+        "modal/clip.jpg",
+        "download/clip.jpg",
+      ])
+    );
+
+    assert.equal(existsSync(path.join(photosDir, album, filename)), false);
+    assert.equal(existsSync(path.join(videoDir, album, filename)), false);
+    for (const dir of ["thumbnail", "modal", "download"]) {
+      assert.equal(existsSync(path.join(optimizedDir, dir, album, poster)), false);
+    }
+    // sibling preserved
+    assert.equal(existsSync(path.join(videoDir, album, "keep.mp4", "master.m3u8")), true);
+    assert.equal(existsSync(path.join(photosDir, album, "keep.mp4")), true);
+    assert.equal(
+      readFileSync(path.join(videoDir, album, "keep.mp4", "master.m3u8"), "utf8"),
+      "#EXTM3U"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("removeMediaDiskAssets is no-op for missing optimized/HLS paths", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "galleria-media-cleanup-missing-"));
+  try {
+    const photosDir = path.join(root, "photos");
+    const optimizedDir = path.join(root, "optimized");
+    const videoDir = path.join(root, "video");
+    const album = "Empty";
+    const filename = "gone.mp4";
+    touch(path.join(photosDir, album, filename));
+
+    const result = removeMediaDiskAssets({
+      photosDir,
+      optimizedDir,
+      videoDir,
+      album,
+      filename,
+    });
+
+    assert.equal(result.originalDeleted, true);
+    assert.equal(result.hlsRemoved, false);
+    assert.equal(result.posterRemoved.length, 0);
+    assert.equal(existsSync(path.join(photosDir, album, filename)), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/backend/src/utils/media-disk-cleanup.ts
+++ b/backend/src/utils/media-disk-cleanup.ts
@@ -1,0 +1,100 @@
+/**
+ * On-disk cleanup for album media deleted via the management API.
+ * Videos leave HLS under videoDir and .jpg posters under optimized — not
+ * the same filename as the original .mp4.
+ */
+
+import fs from "fs";
+import path from "path";
+
+const OPTIMIZED_SUBDIRS = ["thumbnail", "modal", "download"] as const;
+
+export function isVideoFilename(filename: string): boolean {
+  return /\.(mp4|mov|avi|mkv|webm)$/i.test(filename);
+}
+
+export function videoPosterFilename(filename: string): string {
+  return filename.replace(/\.[^.]+$/, ".jpg");
+}
+
+export interface MediaDiskCleanupOptions {
+  photosDir: string;
+  optimizedDir: string;
+  /** When set, removes HLS tree videoDir/<album>/<filename>/ for videos */
+  videoDir?: string | null;
+  album: string;
+  filename: string;
+}
+
+export interface MediaDiskCleanupResult {
+  originalDeleted: boolean;
+  optimizedRemoved: string[];
+  hlsRemoved: boolean;
+  posterRemoved: string[];
+}
+
+/**
+ * Unlink the original file, same-name optimized variants, and (for videos)
+ * the HLS directory tree plus basename.jpg poster files.
+ * Throws if the original is missing (caller should 404 first) only when
+ * deleteOriginal is true and the path does not exist — callers may pass
+ * deleteOriginal: false after they already unlinked.
+ */
+export function removeMediaDiskAssets(
+  options: MediaDiskCleanupOptions & { deleteOriginal?: boolean }
+): MediaDiskCleanupResult {
+  const {
+    photosDir,
+    optimizedDir,
+    videoDir,
+    album,
+    filename,
+    deleteOriginal = true,
+  } = options;
+
+  const result: MediaDiskCleanupResult = {
+    originalDeleted: false,
+    optimizedRemoved: [],
+    hlsRemoved: false,
+    posterRemoved: [],
+  };
+
+  if (deleteOriginal) {
+    const photoPath = path.join(photosDir, album, filename);
+    if (fs.existsSync(photoPath)) {
+      fs.unlinkSync(photoPath);
+      result.originalDeleted = true;
+    }
+  }
+
+  for (const dir of OPTIMIZED_SUBDIRS) {
+    const optimizedPath = path.join(optimizedDir, dir, album, filename);
+    if (fs.existsSync(optimizedPath)) {
+      fs.unlinkSync(optimizedPath);
+      result.optimizedRemoved.push(path.join(dir, filename));
+    }
+  }
+
+  if (!isVideoFilename(filename)) {
+    return result;
+  }
+
+  if (videoDir) {
+    const hlsPath = path.join(videoDir, album, filename);
+    if (fs.existsSync(hlsPath)) {
+      fs.rmSync(hlsPath, { recursive: true, force: true });
+      result.hlsRemoved = true;
+    }
+  }
+
+  const posterName = videoPosterFilename(filename);
+  for (const dir of OPTIMIZED_SUBDIRS) {
+    const posterPath = path.join(optimizedDir, dir, album, posterName);
+    if (fs.existsSync(posterPath)) {
+      fs.unlinkSync(posterPath);
+      result.posterRemoved.push(path.join(dir, posterName));
+    }
+  }
+
+  return result;
+}

--- a/backend/src/utils/rename-rollback.test.ts
+++ b/backend/src/utils/rename-rollback.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { rollbackRenamedPaths, type RenamedPath } from './rename-rollback.js';
+
+test('rollbackRenamedPaths reverses renames LIFO', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'galleria-rename-rollback-'));
+  try {
+    const photosOld = path.join(root, 'photos', 'old-album');
+    const photosNew = path.join(root, 'photos', 'new-album');
+    const thumbOld = path.join(root, 'optimized', 'thumbnail', 'old-album');
+    const thumbNew = path.join(root, 'optimized', 'thumbnail', 'new-album');
+    const videoOld = path.join(root, 'video', 'old-album');
+    const videoNew = path.join(root, 'video', 'new-album');
+
+    mkdirSync(photosNew, { recursive: true });
+    writeFileSync(path.join(photosNew, 'a.jpg'), 'x');
+    mkdirSync(thumbNew, { recursive: true });
+    writeFileSync(path.join(thumbNew, 'a.jpg'), 't');
+    mkdirSync(videoNew, { recursive: true });
+    writeFileSync(path.join(videoNew, 'a.mp4'), 'v');
+
+    const renamed: RenamedPath[] = [
+      { from: photosOld, to: photosNew },
+      { from: thumbOld, to: thumbNew },
+      { from: videoOld, to: videoNew },
+    ];
+
+    rollbackRenamedPaths(renamed);
+
+    assert.equal(existsSync(photosOld), true);
+    assert.equal(existsSync(photosNew), false);
+    assert.equal(existsSync(thumbOld), true);
+    assert.equal(existsSync(thumbNew), false);
+    assert.equal(existsSync(videoOld), true);
+    assert.equal(existsSync(videoNew), false);
+    assert.equal(existsSync(path.join(photosOld, 'a.jpg')), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rollbackRenamedPaths is a no-op for empty list', () => {
+  rollbackRenamedPaths([]);
+});
+
+test('rollbackRenamedPaths skips missing destinations', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'galleria-rename-rollback-missing-'));
+  try {
+    const from = path.join(root, 'old');
+    const to = path.join(root, 'new');
+    // Neither path exists — must not throw
+    rollbackRenamedPaths([{ from, to }]);
+    assert.equal(existsSync(from), false);
+    assert.equal(existsSync(to), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rollbackRenamedPaths restores photos when optimized rename would have failed mid-sequence', () => {
+  // Simulates ticket #3337: photos/ already at new name; optimized half-done;
+  // catch rolls everything tracked back to old names.
+  const root = mkdtempSync(path.join(tmpdir(), 'galleria-rename-mid-fail-'));
+  try {
+    const photosOld = path.join(root, 'photos', 'summer');
+    const photosNew = path.join(root, 'photos', 'summer-2024');
+    const thumbOld = path.join(root, 'optimized', 'thumbnail', 'summer');
+    const thumbNew = path.join(root, 'optimized', 'thumbnail', 'summer-2024');
+    // modal never renamed (failure before it) — not in list
+    const modalOld = path.join(root, 'optimized', 'modal', 'summer');
+
+    mkdirSync(photosNew, { recursive: true });
+    writeFileSync(path.join(photosNew, '1.jpg'), 'photo');
+    mkdirSync(thumbNew, { recursive: true });
+    writeFileSync(path.join(thumbNew, '1.jpg'), 'thumb');
+    mkdirSync(modalOld, { recursive: true });
+    writeFileSync(path.join(modalOld, '1.jpg'), 'modal');
+
+    const renamed: RenamedPath[] = [
+      { from: photosOld, to: photosNew },
+      { from: thumbOld, to: thumbNew },
+      // modal rename never succeeded — not tracked
+    ];
+
+    rollbackRenamedPaths(renamed);
+
+    assert.equal(existsSync(photosOld), true, 'photos restored to old name');
+    assert.equal(existsSync(photosNew), false);
+    assert.equal(existsSync(thumbOld), true, 'thumbnail restored to old name');
+    assert.equal(existsSync(thumbNew), false);
+    assert.equal(existsSync(modalOld), true, 'unmoved modal stays under old name');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/backend/src/utils/rename-rollback.ts
+++ b/backend/src/utils/rename-rollback.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracked filesystem renames with LIFO rollback.
+ * Used by album rename so a mid-sequence fs failure can reverse prior moves.
+ */
+
+import fs from 'fs';
+import { error } from './logger.js';
+
+/** One successful FS rename (old path → new path). */
+export type RenamedPath = { from: string; to: string };
+
+/**
+ * Reverse successful renames in reverse order (best-effort).
+ * Safe to call with an empty list. Logs and continues if a reverse fails.
+ */
+export function rollbackRenamedPaths(renamedPaths: RenamedPath[]): void {
+  for (let i = renamedPaths.length - 1; i >= 0; i--) {
+    const { from, to } = renamedPaths[i];
+    try {
+      if (fs.existsSync(to)) {
+        fs.renameSync(to, from);
+      }
+    } catch (rollbackErr) {
+      error(`[AlbumManagement] Failed to roll back rename ${to} → ${from}:`, rollbackErr);
+    }
+  }
+}

--- a/backend/src/utils/video-processor.spawn-error.test.ts
+++ b/backend/src/utils/video-processor.spawn-error.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Ensures ffmpeg spawn failures reject instead of hanging the Promise.
+ * Trigger: empty PATH so spawn emits ENOENT (same class as missing ffmpeg).
+ */
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { extractThumbnail, generateHLS, rotateVideo } from './video-processor.js';
+
+async function withEmptyPath<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = prev;
+    }
+  }
+}
+
+test('extractThumbnail rejects when ffmpeg spawn fails', async () => {
+  await withEmptyPath(async () => {
+    await assert.rejects(
+      () => extractThumbnail('/tmp/galleria-missing.mp4', '/tmp/galleria-thumb.jpg', 200),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /ffmpeg spawn failed/i);
+        return true;
+      }
+    );
+  });
+});
+
+test('rotateVideo rejects when ffmpeg spawn fails', async () => {
+  await withEmptyPath(async () => {
+    await assert.rejects(
+      () =>
+        rotateVideo(
+          '/tmp/galleria-missing.mp4',
+          '/tmp/galleria-rotated.mp4',
+          { width: 1920, height: 1080, duration: 10, rotation: 90 }
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /ffmpeg spawn failed/i);
+        return true;
+      }
+    );
+  });
+});
+
+test('generateHLS rejects when ffmpeg spawn fails', async () => {
+  await withEmptyPath(async () => {
+    const outDir = path.join('/tmp', `galleria-hls-${process.pid}`);
+    await assert.rejects(
+      () =>
+        generateHLS(
+          '/tmp/galleria-missing.mp4',
+          outDir,
+          { name: '720p', height: 720, videoBitrate: '2500k', audioBitrate: '128k' },
+          4,
+          false
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /ffmpeg spawn failed/i);
+        return true;
+      }
+    );
+  });
+});

--- a/backend/src/utils/video-processor.ts
+++ b/backend/src/utils/video-processor.ts
@@ -253,6 +253,11 @@ export async function rotateVideo(
       }
     });
 
+    // Reject on spawn failure (e.g. ffmpeg missing / ENOENT) so callers do not hang
+    ffmpeg.on('error', (err) => {
+      reject(new Error(`ffmpeg spawn failed: ${err.message}`));
+    });
+
     ffmpeg.on('close', (code) => {
       if (code !== 0) {
         error('[VideoProcessor] Rotation failed:', stderr);
@@ -474,6 +479,11 @@ export async function generateHLS(
       }
     });
 
+    // Reject on spawn failure (e.g. ffmpeg missing / ENOENT) so callers do not hang
+    ffmpeg.on('error', (err) => {
+      reject(new Error(`ffmpeg spawn failed: ${err.message}`));
+    });
+
     ffmpeg.on('close', (code) => {
       if (code !== 0) {
         error(`[VideoProcessor] HLS generation failed for ${resolution.name}:`, stderr);
@@ -513,6 +523,11 @@ export async function extractThumbnail(
     ffmpeg.stderr.on('data', (data) => {
       stderr += data.toString();
       if (onProgress) onProgress(50); // Simple progress indication
+    });
+
+    // Reject on spawn failure (e.g. ffmpeg missing / ENOENT) so callers do not hang
+    ffmpeg.on('error', (err) => {
+      reject(new Error(`ffmpeg spawn failed: ${err.message}`));
     });
 
     ffmpeg.on('close', (code) => {


### PR DESCRIPTION
Combines 8 tickets into a single deployment:

- **#3339**: [bug-scan] Folder delete with deleteAlbums skips videoDir HLS trees
- **#3336**: [bug-scan] Video-optimization cleanup setTimeout nulls a subsequent job
- **#3333**: [bug-scan] Concurrent uploads sharing originalname corrupt the same temp path
- **#3335**: [bug-scan] AI-titles cleanup setTimeout nulls a later job's tracking object
- **#3337**: [bug-scan] Album rename has no FS rollback when a mid-sequence rename throws
- **#3338**: [bug-scan] Video thumbnail upload error path leaves multer temp file
- **#3334**: [bug-scan] rotateVideo/generateHLS/extractThumbnail hang if ffmpeg spawn fails
- **#3332**: [bug-scan] Deleting a video leaves HLS assets playable and .jpg thumbs behind

Tracking ticket: #3372