### PR TITLE
[security-audit] Password-reset request leaks MFA-enabled account existence

### DIFF
--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -619,16 +619,11 @@ router.post('/password-reset/request', async (req: Request, res: Response) => {
 
     const user = getUserByEmail(email);
 
-    // Don't reveal if user exists or not (security best practice)
-    if (!user) {
+    // Uniform response for unknown emails and MFA accounts — do not reveal
+    // registration or MFA status. Self-service reset is only issued for
+    // non-MFA accounts; MFA recovery is via authenticated admin paths.
+    if (!user || user.mfa_enabled) {
       return res.json({ success: true, message: 'If the email exists, a password reset link has been sent' });
-    }
-
-    // Only allow password reset if user doesn't have MFA enabled
-    if (user.mfa_enabled) {
-      return res.status(400).json({ 
-        error: 'Password reset not available for accounts with MFA enabled. Contact an administrator for assistance.' 
-      });
     }
 
     // Generate reset token


### PR DESCRIPTION
# Summary — ticket 3445

## What changed

Unauthenticated `POST /api/auth-extended/password-reset/request` no longer returns 400 when the email belongs to an MFA-enabled account. Unknown emails and MFA accounts both get the same 200 body (`If the email exists, a password reset link has been sent`). No reset token is issued and no email is sent for MFA accounts. Self-service reset still works for non-MFA accounts; MFA recovery remains on authenticated admin routes (`/users/:userId/send-password-reset`, `/users/:userId/reset-mfa`).

## Files

- `backend/src/routes/auth-extended.ts` — collapse MFA early-return into the uniform non-disclosure branch

## Why

Worf finding: distinct 400 for MFA accounts let attackers confirm which registered emails have MFA.

## Verification

- Confirmed leak present before change; 400 MFA string removed from tree after.
- `npm ci --cache /tmp/npm-cache-galleria-3445`
- `npm test --prefix backend` — 36 pass, 0 fail

Implements Orchestrator ticket #3445.