### PR TITLE
[security-audit] CSRF origin check still uses startsWith — confusable subdomain bypass

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import config, { getAllowedOrigins } from './config.js';
 import { info, warn, error, debug, verbose, trace } from './utils/logger.js';
+import { originsEqual } from './utils/origins-equal.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -181,8 +182,8 @@ export function csrfProtection(req: any, res: any, next: any) {
     // Get dynamic allowed origins (includes config.json values)
     const allowedOrigins = getAllowedOrigins();
     
-    // Check exact match first
-    let isAllowedOrigin = allowedOrigins.some((allowed: string) => origin.startsWith(allowed));
+    // Exact origin match (not startsWith — confusable subdomain bypass)
+    let isAllowedOrigin = allowedOrigins.some((allowed: string) => originsEqual(origin, allowed));
     
     // If not in allowed list, check for localhost
     if (!isAllowedOrigin) {

--- a/backend/src/utils/origins-equal.test.ts
+++ b/backend/src/utils/origins-equal.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { originsEqual } from './origins-equal.js';
+
+const allowed = 'https://www.example.com';
+
+test('accepts exact allowed origin', () => {
+  assert.equal(originsEqual('https://www.example.com', allowed), true);
+});
+
+test('accepts allowed origin with trailing path/slash via URL.origin', () => {
+  assert.equal(originsEqual('https://www.example.com/', allowed), true);
+  assert.equal(originsEqual('https://www.example.com/admin', allowed), true);
+  assert.equal(originsEqual(allowed, 'https://www.example.com/'), true);
+});
+
+test('rejects confusable subdomain (startsWith bypass)', () => {
+  // Previously origin.startsWith(allowed) accepted this attacker origin
+  assert.equal(originsEqual('https://www.example.com.evil.tld', allowed), false);
+  assert.equal(originsEqual('https://www.example.com.attacker.com', allowed), false);
+});
+
+test('rejects different scheme or host', () => {
+  assert.equal(originsEqual('http://www.example.com', allowed), false);
+  assert.equal(originsEqual('https://evil.example.com', allowed), false);
+  assert.equal(originsEqual('https://www.example.com:8443', allowed), false);
+});
+
+test('normalizes default HTTPS port', () => {
+  assert.equal(originsEqual('https://www.example.com:443', allowed), true);
+  assert.equal(originsEqual(allowed, 'https://www.example.com:443'), true);
+});
+
+test('rejects invalid URLs', () => {
+  assert.equal(originsEqual('not-a-url', allowed), false);
+  assert.equal(originsEqual(allowed, 'not-a-url'), false);
+  assert.equal(originsEqual('', allowed), false);
+});

--- a/backend/src/utils/origins-equal.ts
+++ b/backend/src/utils/origins-equal.ts
@@ -1,0 +1,13 @@
+/**
+ * Exact origin equality (scheme + host + port via URL.origin).
+ * Rejects confusable subdomain prefixes that string startsWith would accept
+ * (e.g. https://www.example.com.evil.tld when allowed is https://www.example.com).
+ * Regression of #537 / ticket 3439.
+ */
+export function originsEqual(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
# Summary — ticket 3439 CSRF origin startsWith bypass

## What changed
`csrfProtection` in `backend/src/security.ts` compared request Origin/Referer with `origin.startsWith(allowed)`. That accepted confusable attacker origins such as `https://www.example.com.evil.tld` when the allow-list held `https://www.example.com` (regression of #537 exact-origin equality).

Fix: pure helper `originsEqual(a, b)` → `new URL(a).origin === new URL(b).origin` (false on parse failure). CSRF allow-list check now uses that; localhost and IP:3000|3001 exceptions unchanged.

## Files
- `backend/src/utils/origins-equal.ts` — helper
- `backend/src/utils/origins-equal.test.ts` — unit tests (confusable subdomain reject, exact match, :443 normalize, invalid URL)
- `backend/src/security.ts` — CSRF uses `originsEqual`
- `backend/package.json` — include new test in `npm test`

## Verification
- `npm ci --cache /tmp/npm-cache-galleria-3439` in `backend/` (default npm cache EACCES)
- `node --test ... src/utils/origins-equal.test.ts` — 6/6 pass
- Full `npm test` still has pre-existing env failures (`sharp` missing for album-access suite; unrelated to this change)

## Out of scope
Same `startsWith` pattern remains in `backend/src/routes/analytics.ts` (analytics proxy origin gate, not CSRF). Follow-up ticket filed if create_ticket succeeds.

Implements Orchestrator ticket #3439.