### PR TITLE
[security-audit] GET /users still requireAuth and returns invite tokens to viewers

### DIFF
--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1472,8 +1472,9 @@ router.delete('/passkey/:id', requireAuth, async (req: Request, res: Response) =
 
 /**
  * List all users (admin only)
+ * Does not return invite_token — use GET /users/:userId/invite-link for copy-link.
  */
-router.get('/users', requireAuth, (req: Request, res: Response) => {
+router.get('/users', requireAdmin, (req: Request, res: Response) => {
   try {
     const users = getAllUsers();
     
@@ -1481,7 +1482,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
     const sanitizedUsers = users.map((user: User) => {
       // Determine display status based on user state
       let displayStatus = null;
-      let inviteToken = null;
       
       if (user.status === 'invited') {
         // Check if invite has expired
@@ -1495,9 +1495,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         } else {
           displayStatus = 'invited';
         }
-        
-        // Include invite token for invited/expired users (needed for copy link functionality)
-        inviteToken = user.invite_token;
       }
       
       return {
@@ -1510,7 +1507,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         passkey_count: user.passkeys?.length || 0,
         is_active: user.is_active,
         status: displayStatus, // Only show status if invited or expired
-        invite_token: inviteToken, // Include for invited users
         created_at: user.created_at,
         last_login_at: user.last_login_at,
       };
@@ -1520,6 +1516,36 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
   } catch (err) {
     error('[AuthExtended] List users error:', err);
     res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+/**
+ * Get invite URL for an invited user (admin only — copy-link; never bulk-list tokens)
+ */
+router.get('/users/:userId/invite-link', requireAdmin, (req: Request, res: Response) => {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    if (Number.isNaN(userId)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+
+    const user = getUserById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (user.status !== 'invited' && user.status !== 'invite_expired') {
+      return res.status(400).json({ error: 'User has no pending invitation' });
+    }
+
+    if (!user.invite_token) {
+      return res.status(404).json({ error: 'Invitation token not found' });
+    }
+
+    res.json({ inviteUrl: generateInvitationUrl(user.invite_token) });
+  } catch (err) {
+    error('[AuthExtended] Get invite link error:', err);
+    res.status(500).json({ error: 'Failed to get invitation link' });
   }
 });
 

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from 'react-i18next';
 import type { User } from "./types";
-import { getGravatarUrl, copyInvitationUrl } from "./utils";
+import { getGravatarUrl, userManagementAPI } from "./utils";
 import { error, info } from '../../../../../utils/logger';
 
 interface UserCardProps {
@@ -46,10 +46,9 @@ export const UserCard: React.FC<UserCardProps> = ({
   }
 
   const handleCopyInvite = async () => {
-    if (!user.invite_token) return;
-    
     try {
-      await copyInvitationUrl(user.invite_token);
+      const { inviteUrl } = await userManagementAPI.getInviteLink(user.id);
+      await navigator.clipboard.writeText(inviteUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -454,7 +453,7 @@ export const UserCard: React.FC<UserCardProps> = ({
       {currentUser && (
         <>
           {/* Invited/Expired Users - Show Copy Invite */}
-          {(user.status === "invited" || user.status === "invite_expired") && user.invite_token && (
+          {(user.status === "invited" || user.status === "invite_expired") && (
             <div
               style={{
                 display: "flex",

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
@@ -9,6 +9,7 @@ export interface User {
   auth_methods: string[];
   status?: string;
   picture?: string;
+  /** Present only on create-invite response, never on list payload */
   invite_token?: string | null;
 }
 

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
@@ -70,6 +70,17 @@ export const userManagementAPI = {
     return data.users || [];
   },
 
+  async getInviteLink(userId: number): Promise<{ inviteUrl: string }> {
+    const res = await fetch(`${API_URL}/api/auth-extended/users/${userId}/invite-link`, {
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to get invitation link');
+    }
+    return await res.json();
+  },
+
   async checkSmtpConfig() {
     const res = await fetch(`${API_URL}/api/config`, {
       credentials: 'include',


### PR DESCRIPTION
# Summary — #3443 GET /users requireAuth + invite_token leak

## What changed
Security fix for regression of closed #884/#819: `GET /api/auth-extended/users` was gated with `requireAuth` (any authenticated viewer) and returned raw `invite_token` for pending invites. Viewers could list emails/roles/MFA/passkey counts and steal invite tokens usable on unauthenticated `POST /invite/:token/complete`.

## Fix
1. Switched list route to `requireAdmin`.
2. Removed `invite_token` from the list response (status-only for invite state).
3. Added admin-only `GET /api/auth-extended/users/:userId/invite-link` returning `{ inviteUrl }` for copy-link.
4. User management UI fetches that endpoint when copying an invite; no longer relies on tokens in the list payload.

## Files
- `backend/src/routes/auth-extended.ts` — requireAdmin, strip token, new invite-link route
- `frontend/.../UserManagement/UserCard.tsx` — copy via API
- `frontend/.../UserManagement/utils.ts` — `getInviteLink`
- `frontend/.../UserManagement/types.ts` — note on invite_token scope

## Verification
- `npm ci --cache /tmp/npm-cache-galleria-3443` (default cache had EACCES)
- `npm test --prefix backend` — 36 pass, 0 fail
- `npx tsc --noEmit` (backend) — clean

## Note
`POST /invite` still returns `invite_token` once to the inviting admin (create flow / NewUserForm). List no longer bulk-exposes tokens.

Implements Orchestrator ticket #3443.