### PR TITLE
[security-audit] Video routes still reflect Origin with credentials (CORS allowlist bypass)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/config.origin-allowed.test.ts
+++ b/backend/src/config.origin-allowed.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getAllowedOrigins, getConfigExists, isOriginAllowed } from './config.js';
+
+test('allows exact origins from getAllowedOrigins', () => {
+  const allowed = getAllowedOrigins();
+  assert.ok(allowed.length > 0, 'expected at least localhost defaults');
+  for (const origin of allowed) {
+    assert.equal(isOriginAllowed(origin), true, origin);
+  }
+});
+
+test('allows localhost and 127.0.0.1 on any port', () => {
+  assert.equal(isOriginAllowed('http://localhost:9999'), true);
+  assert.equal(isOriginAllowed('http://127.0.0.1:5173'), true);
+});
+
+test('allows IPv4 Docker/Unraid ports 3000 and 3001 only', () => {
+  assert.equal(isOriginAllowed('http://192.168.1.50:3000'), true);
+  assert.equal(isOriginAllowed('http://10.0.0.2:3001'), true);
+  assert.equal(isOriginAllowed('http://192.168.1.50:8080'), false);
+});
+
+test('rejects unlisted third-party origins (CORS bypass class)', () => {
+  // HTTP third-party never passes (OOBE only opens https when config is missing)
+  assert.equal(isOriginAllowed('http://evil.example'), false);
+  assert.equal(isOriginAllowed('http://attacker.example.com'), false);
+  assert.equal(isOriginAllowed('http://evil.example:3000'), false);
+
+  if (getConfigExists()) {
+    assert.equal(isOriginAllowed('https://evil.example'), false);
+    assert.equal(isOriginAllowed('https://attacker.example.com'), false);
+  } else {
+    // Matches global server CORS: OOBE allows any HTTPS origin during setup
+    assert.equal(isOriginAllowed('https://evil.example'), true);
+  }
+});
+
+test('rejects missing/empty origin', () => {
+  assert.equal(isOriginAllowed(undefined), false);
+  assert.equal(isOriginAllowed(null), false);
+  assert.equal(isOriginAllowed(''), false);
+});
+
+test('rejects malformed origin URLs', () => {
+  assert.equal(isOriginAllowed('not-a-url'), false);
+});

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -207,6 +207,49 @@ export function getAllowedOrigins(): string[] {
   return uniqueOrigins;
 }
 
+/**
+ * Whether a request Origin may be reflected with Access-Control-Allow-Credentials.
+ * Mirrors the global CORS origin callback in server.ts so route-level headers
+ * cannot bypass the allowlist (credentialed ACAO must never be set for unlisted origins).
+ */
+export function isOriginAllowed(origin: string | undefined | null): boolean {
+  if (!origin) {
+    return false;
+  }
+
+  // During OOBE (setup mode), allow any HTTPS origin — same as server CORS
+  if (!getConfigExists() && origin.startsWith("https://")) {
+    return true;
+  }
+
+  const allowedOrigins = getAllowedOrigins();
+  if (allowedOrigins.indexOf(origin) !== -1) {
+    return true;
+  }
+
+  try {
+    const url = new URL(origin);
+    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+      return true;
+    }
+
+    // Docker / Unraid direct access: any IPv4 on ports 3000 or 3001
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : url.protocol === "https:"
+        ? 443
+        : 80;
+    const ipPattern = /^\d+\.\d+\.\d+\.\d+$/;
+    if (ipPattern.test(url.hostname) && (port === 3000 || port === 3001)) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
 // Export constants
 export const PORT = process.env.PORT
   ? parseInt(process.env.PORT)

--- a/backend/src/routes/video.ts
+++ b/backend/src/routes/video.ts
@@ -10,8 +10,33 @@ import { error, info } from '../utils/logger.js';
 import { getAlbumState, getShareLinkBySecret, isShareLinkExpired } from '../database.js';
 import { requireAuth } from '../auth/middleware.js';
 import { isRequestAuthenticated } from '../utils/album-access.js';
+import { isOriginAllowed } from '../config.js';
 
 const router = Router();
+
+/**
+ * Reflect Origin only when it passes the global allowlist.
+ * Unconditional reflection + credentials bypassed server CORS (regression of #821).
+ */
+const setCredentialedCorsHeaders = (req: Request, res: Response): void => {
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && isOriginAllowed(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+};
+
+/** Same rules for writeHead() paths that cannot call setHeader after headers start. */
+const credentialedCorsHeaderRecord = (req: Request): Record<string, string> => {
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && isOriginAllowed(origin)) {
+    return {
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Credentials': 'true',
+    };
+  }
+  return {};
+};
 
 /**
  * Sanitize path components to prevent directory traversal
@@ -65,12 +90,7 @@ const appendKeyToPlaylistUris = (content: string, key: string): string => {
 const sendPlaylist = (req: Request, res: Response, playlistPath: string): void => {
   res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
   res.setHeader('Cache-Control', 'public, max-age=3600');
-
-  const origin = req.headers.origin;
-  if (origin) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-  }
+  setCredentialedCorsHeaders(req, res);
 
   const shareKey = getShareKeyFromQuery(req);
   if (shareKey) {
@@ -337,13 +357,7 @@ router.get("/:album/:filename/:resolution/:segment", async (req: Request, res: R
     // Set appropriate headers for MPEG-TS segments
     res.setHeader('Content-Type', 'video/mp2t');
     res.setHeader('Cache-Control', 'public, max-age=31536000'); // Cache segments for 1 year
-    
-    // Set CORS headers to allow credentials
-    const origin = req.headers.origin;
-    if (origin) {
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Access-Control-Allow-Credentials', 'true');
-    }
+    setCredentialedCorsHeaders(req, res);
 
     // Send the segment file
     res.sendFile(segmentPath);
@@ -485,8 +499,7 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
         'Accept-Ranges': 'bytes',
         'Content-Length': chunksize,
         'Content-Type': 'video/mp4',
-        'Access-Control-Allow-Origin': req.headers.origin || '*',
-        'Access-Control-Allow-Credentials': 'true',
+        ...credentialedCorsHeaderRecord(req),
       });
 
       file.pipe(res);
@@ -496,8 +509,7 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
         'Content-Length': fileSize,
         'Content-Type': 'video/mp4',
         'Accept-Ranges': 'bytes',
-        'Access-Control-Allow-Origin': req.headers.origin || '*',
-        'Access-Control-Allow-Credentials': 'true',
+        ...credentialedCorsHeaderRecord(req),
       });
 
       fs.createReadStream(rotatedVideoPath).pipe(res);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,8 +25,8 @@ import config, {
   PHOTOS_DIR,
   OPTIMIZED_DIR,
   DATA_DIR,
-  getAllowedOrigins,
   getConfigExists,
+  isOriginAllowed,
   RATE_LIMIT_WINDOW_MS,
   RATE_LIMIT_MAX_REQUESTS,
   getLogLevel,
@@ -277,55 +277,8 @@ app.use(
       // Allow requests with no origin (mobile apps, curl, etc.)
       if (!origin) return callback(null, true);
 
-      // Get current state (dynamic, updates after config changes)
-      const configExists = getConfigExists();
-      const allowedOrigins = getAllowedOrigins();
-
-      // During OOBE (setup mode), allow any HTTPS origin to enable setup from any domain
-      if (!configExists && origin.startsWith("https://")) {
-        trace(`[OOBE] Allowing CORS from: ${origin}`);
+      if (isOriginAllowed(origin)) {
         return callback(null, true);
-      }
-
-      // Check exact matches first
-      if (allowedOrigins.indexOf(origin) !== -1) {
-        callback(null, true);
-        return;
-      }
-
-      // Allow localhost on any port (for development)
-      try {
-        const url = new URL(origin);
-        if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-          callback(null, true);
-          return;
-        }
-      } catch (e) {
-        // Invalid URL, continue to other checks
-      }
-
-      // Allow any IP address on ports 3000 and 3001 (for Docker direct access)
-      // Pattern: http://<any-ip>:3000 or http://<any-ip>:3001
-      try {
-        const url = new URL(origin);
-        const port = url.port
-          ? parseInt(url.port)
-          : url.protocol === "https:"
-          ? 443
-          : 80;
-
-        // Check if hostname is an IP address (IPv4 pattern)
-        const hostname = url.hostname;
-        const ipPattern = /^\d+\.\d+\.\d+\.\d+$/;
-        const isIpAddress = ipPattern.test(hostname);
-
-        if (isIpAddress && (port === 3000 || port === 3001)) {
-          trace(`[CORS] Allowing IP-based access: ${origin}`);
-          callback(null, true);
-          return;
-        }
-      } catch (e) {
-        // Invalid URL, continue to rejection
       }
 
       // Reject origin by passing false (not an Error)


### PR DESCRIPTION
# Summary — ticket 3442

## What / why

Video playlist, segment, and `original.mp4` handlers reflected any `Origin` with `Access-Control-Allow-Credentials: true` (mp4 also fell back to `*`), overriding the global CORS allowlist. That let third-party pages read credentialed video responses for albums the victim session can access (Worf finding; regression class of #821).

## Changes

- `backend/src/config.ts` — added `isOriginAllowed()` (exact allowlist from `getAllowedOrigins`, localhost/127.0.0.1 any port, IPv4 on :3000/:3001, OOBE HTTPS when config missing — same rules as former server CORS callback).
- `backend/src/routes/video.ts` — playlist, segment, and original.mp4 paths only set credentialed ACAO when `isOriginAllowed`; no `*` + credentials.
- `backend/src/server.ts` — CORS origin callback uses `isOriginAllowed` so route-level and global rules cannot drift.
- `backend/src/config.origin-allowed.test.ts` + `backend/package.json` test script entry.

## Verification

- `npm ci --cache /tmp/npm-cache-galleria` (default npm cache was EACCES)
- `cd backend && npm test` — 42/42 pass
- `cd backend && npx tsc --noEmit` — clean

## Files

- `backend/src/config.ts`
- `backend/src/routes/video.ts`
- `backend/src/server.ts`
- `backend/src/config.origin-allowed.test.ts`
- `backend/package.json`

Implements Orchestrator ticket #3442.