### PR TITLE
[security-audit] MFA disable and backup-codes skip re-auth for passwordless users

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/auth/reauth.test.ts
+++ b/backend/src/auth/reauth.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  REAUTH_WINDOW_MS,
+  isRecentAuth,
+  planSensitiveReauth,
+  userHasPasskeys,
+  userHasPassword,
+} from './reauth.js';
+
+test('userHasPassword treats null/empty as absent', () => {
+  assert.equal(userHasPassword({ password_hash: null }), false);
+  assert.equal(userHasPassword({ password_hash: '' }), false);
+  assert.equal(userHasPassword({ password_hash: 'hash' }), true);
+});
+
+test('userHasPasskeys requires non-empty array', () => {
+  assert.equal(userHasPasskeys({ passkeys: null }), false);
+  assert.equal(userHasPasskeys({ passkeys: [] }), false);
+  assert.equal(userHasPasskeys({ passkeys: [{ id: '1' }] }), true);
+});
+
+test('isRecentAuth fails closed on missing timestamps', () => {
+  const now = 1_000_000;
+  assert.equal(isRecentAuth(undefined, now), false);
+  assert.equal(isRecentAuth(null, now), false);
+  assert.equal(isRecentAuth(Number.NaN, now), false);
+});
+
+test('isRecentAuth accepts only within window', () => {
+  const now = 1_000_000;
+  assert.equal(isRecentAuth(now, now), true);
+  assert.equal(isRecentAuth(now - REAUTH_WINDOW_MS, now), true);
+  assert.equal(isRecentAuth(now - REAUTH_WINDOW_MS - 1, now), false);
+  assert.equal(isRecentAuth(now + 1, now), false); // future clock skew rejected
+});
+
+test('password account requires password; session alone never enough', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: false,
+    sessionAuthenticatedAt: Date.now(),
+  });
+  assert.equal(plan.action, 'reject');
+  if (plan.action === 'reject') {
+    assert.equal(plan.code, 'password_required');
+    assert.ok(plan.availableMethods.includes('password'));
+    assert.ok(!plan.availableMethods.includes('recent_login'));
+  }
+});
+
+test('password account with password plans verify_password', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: false,
+    password: 'secret',
+  });
+  assert.deepEqual(plan, { action: 'verify_password', password: 'secret' });
+});
+
+test('password account may use passkey when both registered', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: true,
+    passkeyCredential: { id: 'cred' },
+    passkeySessionId: 'sid-1',
+  });
+  assert.equal(plan.action, 'verify_passkey');
+  if (plan.action === 'verify_passkey') {
+    assert.equal(plan.sessionId, 'sid-1');
+  }
+});
+
+test('passwordless passkey user without proof is rejected (regression #3440)', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: true,
+    // stale / missing session auth time
+    sessionAuthenticatedAt: Date.now() - REAUTH_WINDOW_MS - 10_000,
+  });
+  assert.equal(plan.action, 'reject');
+  if (plan.action === 'reject') {
+    assert.equal(plan.code, 'passkey_reauth_required');
+  }
+});
+
+test('passwordless passkey user accepts fresh passkey assertion', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: true,
+    passkeyCredential: { id: 'cred' },
+    passkeySessionId: 'reauth-1',
+  });
+  assert.equal(plan.action, 'verify_passkey');
+});
+
+test('passwordless passkey user accepts recent login', () => {
+  const now = 5_000_000;
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: true,
+    sessionAuthenticatedAt: now - 60_000,
+    now,
+  });
+  assert.equal(plan.action, 'accept_recent_login');
+});
+
+test('OAuth-only without recent login is rejected (session theft path)', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: false,
+    sessionAuthenticatedAt: undefined,
+  });
+  assert.equal(plan.action, 'reject');
+  if (plan.action === 'reject') {
+    assert.equal(plan.code, 'reauth_required');
+    assert.deepEqual(plan.availableMethods, ['recent_login']);
+  }
+});
+
+test('OAuth-only with recent login is accepted', () => {
+  const now = 9_000_000;
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: false,
+    sessionAuthenticatedAt: now - 30_000,
+    now,
+  });
+  assert.equal(plan.action, 'accept_recent_login');
+});
+
+test('empty password string does not count as provided', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: false,
+    password: '',
+  });
+  assert.equal(plan.action, 'reject');
+});

--- a/backend/src/auth/reauth.ts
+++ b/backend/src/auth/reauth.ts
@@ -1,0 +1,146 @@
+/**
+ * Step-up re-authentication for sensitive account actions (MFA disable, backup codes).
+ *
+ * Rules (ticket #3440 / #536 class):
+ * - Password present → must prove password (session alone is never enough)
+ * - Passwordless with passkeys → fresh passkey assertion OR recent-login window
+ * - OAuth-only (no password, no passkey) → recent-login window only
+ */
+
+/** Max age of session.authenticatedAt accepted as "recent login" proof. */
+export const REAUTH_WINDOW_MS = 5 * 60 * 1000;
+
+export type ReauthMethod = 'password' | 'passkey' | 'recent_login';
+
+export type ReauthPlan =
+  | { action: 'verify_password'; password: string }
+  | { action: 'verify_passkey'; credential: unknown; sessionId: string }
+  | { action: 'accept_recent_login' }
+  | {
+      action: 'reject';
+      status: number;
+      error: string;
+      code: string;
+      availableMethods: ReauthMethod[];
+    };
+
+export function userHasPassword(user: { password_hash?: string | null }): boolean {
+  return typeof user.password_hash === 'string' && user.password_hash.length > 0;
+}
+
+export function userHasPasskeys(user: { passkeys?: unknown[] | null }): boolean {
+  return Array.isArray(user.passkeys) && user.passkeys.length > 0;
+}
+
+/**
+ * True when authenticatedAt is a finite timestamp within the reauth window of `now`.
+ * Missing / non-finite timestamps fail closed (not recent).
+ */
+export function isRecentAuth(
+  authenticatedAt: number | null | undefined,
+  now: number = Date.now(),
+  windowMs: number = REAUTH_WINDOW_MS
+): boolean {
+  if (authenticatedAt == null || !Number.isFinite(authenticatedAt)) {
+    return false;
+  }
+  const age = now - authenticatedAt;
+  return age >= 0 && age <= windowMs;
+}
+
+function availableMethods(hasPassword: boolean, hasPasskeys: boolean): ReauthMethod[] {
+  const methods: ReauthMethod[] = [];
+  if (hasPassword) methods.push('password');
+  if (hasPasskeys) methods.push('passkey');
+  if (!hasPassword) methods.push('recent_login');
+  return methods;
+}
+
+/**
+ * Decide how to re-prove identity for a sensitive action.
+ * Does not perform crypto; callers verify password/passkey after this plan.
+ */
+export function planSensitiveReauth(input: {
+  hasPassword: boolean;
+  hasPasskeys: boolean;
+  password?: string | null;
+  passkeyCredential?: unknown;
+  passkeySessionId?: string | null;
+  sessionAuthenticatedAt?: number | null;
+  now?: number;
+  windowMs?: number;
+}): ReauthPlan {
+  const {
+    hasPassword,
+    hasPasskeys,
+    password,
+    passkeyCredential,
+    passkeySessionId,
+    sessionAuthenticatedAt,
+    now = Date.now(),
+    windowMs = REAUTH_WINDOW_MS,
+  } = input;
+
+  const methods = availableMethods(hasPassword, hasPasskeys);
+  const passwordProvided = typeof password === 'string' && password.length > 0;
+  const passkeyProvided =
+    passkeyCredential != null &&
+    typeof passkeySessionId === 'string' &&
+    passkeySessionId.length > 0;
+
+  // Password accounts: always require password proof (session theft must not disable MFA).
+  if (hasPassword) {
+    if (passwordProvided) {
+      return { action: 'verify_password', password: password as string };
+    }
+    // Optional: allow passkey step-up for hybrid password+passkey accounts.
+    if (passkeyProvided && hasPasskeys) {
+      return {
+        action: 'verify_passkey',
+        credential: passkeyCredential,
+        sessionId: passkeySessionId as string,
+      };
+    }
+    return {
+      action: 'reject',
+      status: 401,
+      error: 'Password required',
+      code: 'password_required',
+      availableMethods: methods,
+    };
+  }
+
+  // Passwordless with passkeys: assertion or recent login.
+  if (hasPasskeys) {
+    if (passkeyProvided) {
+      return {
+        action: 'verify_passkey',
+        credential: passkeyCredential,
+        sessionId: passkeySessionId as string,
+      };
+    }
+    if (isRecentAuth(sessionAuthenticatedAt, now, windowMs)) {
+      return { action: 'accept_recent_login' };
+    }
+    return {
+      action: 'reject',
+      status: 401,
+      error: 'Re-authentication required',
+      code: 'passkey_reauth_required',
+      availableMethods: methods,
+    };
+  }
+
+  // OAuth-only: recent login only (no interactive second factor registered).
+  if (isRecentAuth(sessionAuthenticatedAt, now, windowMs)) {
+    return { action: 'accept_recent_login' };
+  }
+
+  return {
+    action: 'reject',
+    status: 401,
+    error: 'Re-authentication required. Sign in again to continue.',
+    code: 'reauth_required',
+    availableMethods: methods,
+  };
+}

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -43,6 +43,11 @@ import {
   generatePasskeyAuthenticationOptions,
   verifyPasskeyAuthentication,
 } from '../auth/passkeys.js';
+import {
+  planSensitiveReauth,
+  userHasPasskeys,
+  userHasPassword,
+} from '../auth/reauth.js';
 import crypto from 'crypto';
 import { sendInvitationEmail, sendPasswordResetEmail, isEmailServiceEnabled, generateInvitationUrl } from '../email.js';
 import { getCurrentConfig, reloadConfig } from '../config.js';
@@ -51,6 +56,97 @@ import { translateNotification } from '../i18n-backend.js';
 import { destroySessionsForUser } from '../auth/session-invalidation.js';
 
 const router = Router();
+
+/**
+ * Step-up re-auth for MFA disable / backup-code mint.
+ * Password when present; else passkey assertion or recent-login window.
+ * Returns null on success, or an Express response already sent.
+ */
+async function requireSensitiveReauth(
+  req: Request,
+  res: Response,
+  user: User
+): Promise<true | null> {
+  const {
+    password,
+    passkeyCredential,
+    passkeySessionId,
+    // alternate names clients may send
+    credential,
+    sessionId,
+  } = req.body || {};
+
+  const plan = planSensitiveReauth({
+    hasPassword: userHasPassword(user),
+    hasPasskeys: userHasPasskeys(user),
+    password,
+    passkeyCredential: passkeyCredential ?? credential,
+    passkeySessionId: passkeySessionId ?? sessionId,
+    sessionAuthenticatedAt: (req.session as any)?.authenticatedAt,
+  });
+
+  if (plan.action === 'reject') {
+    res.status(plan.status).json({
+      error: plan.error,
+      code: plan.code,
+      availableMethods: plan.availableMethods,
+    });
+    return null;
+  }
+
+  if (plan.action === 'accept_recent_login') {
+    return true;
+  }
+
+  if (plan.action === 'verify_password') {
+    if (!verifyPassword(user, plan.password)) {
+      res.status(401).json({ error: 'Invalid password', code: 'invalid_password' });
+      return null;
+    }
+    return true;
+  }
+
+  // verify_passkey
+  const challengeKey = `passkey-reauth-${plan.sessionId}`;
+  const stored = challenges.get(challengeKey);
+  if (!stored || stored.userId !== user.id || stored.expires < Date.now()) {
+    res.status(400).json({
+      error: 'Invalid or expired passkey reauth challenge',
+      code: 'passkey_challenge_invalid',
+    });
+    return null;
+  }
+
+  const credentialPayload = plan.credential as { id?: string };
+  if (!credentialPayload?.id) {
+    res.status(400).json({ error: 'Missing passkey credential', code: 'passkey_required' });
+    return null;
+  }
+
+  const result = getPasskeyByCredentialId(credentialPayload.id);
+  if (!result || result.user.id !== user.id) {
+    res.status(400).json({ error: 'Passkey not found', code: 'passkey_not_found' });
+    return null;
+  }
+
+  const verification = await verifyPasskeyAuthentication(
+    plan.credential as any,
+    stored.challenge,
+    result.passkey.credentialPublicKey,
+    result.passkey.counter
+  );
+
+  if (!verification.verified) {
+    res.status(401).json({ error: 'Passkey verification failed', code: 'passkey_invalid' });
+    return null;
+  }
+
+  updatePasskeyCounter(user.id, result.passkey.id, verification.authenticationInfo.newCounter);
+  challenges.delete(challengeKey);
+  // Refresh authenticatedAt so subsequent sensitive ops in-window succeed without re-prompt.
+  (req.session as any).authenticatedAt = Date.now();
+  return true;
+}
 
 /**
  * Helper to send push notification to all admin users
@@ -258,6 +354,7 @@ router.post('/login', async (req: Request, res: Response) => {
       }
 
       (req.session as any).userId = user.id;
+      (req.session as any).authenticatedAt = Date.now();
       (req.session as any).user = {
         id: user.id,
         email: user.email,
@@ -1044,6 +1141,7 @@ router.post('/mfa/verify-setup', requireAuth, async (req: Request, res: Response
 
 /**
  * Disable MFA
+ * Requires step-up reauth: password if set, else passkey assertion or recent login.
  */
 router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => {
   try {
@@ -1051,16 +1149,15 @@ router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => 
     if (!userId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
-    const { password } = req.body;
 
     const user = getUserById(userId);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    // Verify password before disabling MFA
-    if (user.password_hash && !verifyPassword(user, password)) {
-      return res.status(401).json({ error: 'Invalid password' });
+    const reauthOk = await requireSensitiveReauth(req, res, user);
+    if (!reauthOk) {
+      return;
     }
 
     disableMFA(userId);
@@ -1093,6 +1190,7 @@ router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => 
 
 /**
  * Get new backup codes
+ * Requires step-up reauth: password if set, else passkey assertion or recent login.
  */
 router.post('/mfa/backup-codes', requireAuth, async (req: Request, res: Response) => {
   try {
@@ -1100,16 +1198,15 @@ router.post('/mfa/backup-codes', requireAuth, async (req: Request, res: Response
     if (!userId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
-    const { password } = req.body;
 
     const user = getUserById(userId);
     if (!user || !user.mfa_enabled) {
       return res.status(400).json({ error: 'MFA is not enabled' });
     }
 
-    // Verify password
-    if (user.password_hash && !verifyPassword(user, password)) {
-      return res.status(401).json({ error: 'Invalid password' });
+    const reauthOk = await requireSensitiveReauth(req, res, user);
+    if (!reauthOk) {
+      return;
     }
 
     // Generate new backup codes
@@ -1248,6 +1345,44 @@ router.post('/passkey/register-verify', requireAuth, async (req: Request, res: R
 });
 
 /**
+ * Generate passkey options for step-up reauth (sensitive actions while already logged in).
+ * Challenge is stored under passkey-reauth-${sessionId} and consumed by requireSensitiveReauth.
+ */
+router.post('/passkey/reauth-options', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = getUserIdFromRequest(req);
+    if (!userId) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+
+    const user = getUserById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (!userHasPasskeys(user)) {
+      return res.status(400).json({
+        error: 'No passkeys registered',
+        code: 'no_passkeys',
+      });
+    }
+
+    const options = await generatePasskeyAuthenticationOptions(user.passkeys || []);
+    const sessionId = crypto.randomUUID();
+    challenges.set(`passkey-reauth-${sessionId}`, {
+      challenge: options.challenge,
+      userId,
+      expires: Date.now() + 5 * 60 * 1000,
+    });
+
+    res.json({ ...options, sessionId });
+  } catch (err) {
+    error('[AuthExtended] Passkey reauth options error:', err);
+    res.status(500).json({ error: 'Failed to generate reauth options' });
+  }
+});
+
+/**
  * Get authentication options for passkey login
  */
 router.post('/passkey/auth-options', async (req: Request, res: Response) => {
@@ -1347,6 +1482,7 @@ router.post('/passkey/auth-verify', async (req: Request, res: Response) => {
       }
 
       (req.session as any).userId = user.id;
+      (req.session as any).authenticatedAt = Date.now();
       (req.session as any).user = {
         id: user.id,
         email: user.email,

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -277,6 +277,9 @@ router.get(
           });
           return res.redirect(`${frontendUrl}/auth/error?reason=failed`);
         }
+
+        // Stamp for sensitive-action reauth window (MFA disable / backup codes)
+        (req.session as any).authenticatedAt = Date.now();
         
         // Explicitly save the session before redirecting
         req.session.save(async (err) => {


### PR DESCRIPTION
# Ticket 3440 — MFA disable / backup-codes skip re-auth for passwordless users

## What changed
Closed the session-theft hole on `POST /api/auth-extended/mfa/disable` and `/mfa/backup-codes`. Both used `if (user.password_hash && !verifyPassword(...))`, so OAuth/passkey-only accounts (null `password_hash`) ran disable/mint with only a stolen cookie.

## Fix
- New pure planner: `backend/src/auth/reauth.ts` + unit tests `reauth.test.ts`
  - Password present → must prove password (recent-login never enough)
  - Passwordless + passkeys → passkey assertion or 5-minute recent-login window
  - OAuth-only → recent-login only; else `reauth_required`
- Shared `requireSensitiveReauth` in `auth-extended.ts` used by both MFA handlers
- `POST /passkey/reauth-options` (requireAuth) issues step-up challenges
- Stamp `session.authenticatedAt` on password login, passkey login, and Google OAuth login

## Files
- `backend/src/auth/reauth.ts` (new)
- `backend/src/auth/reauth.test.ts` (new)
- `backend/src/routes/auth-extended.ts`
- `backend/src/routes/auth.ts`
- `backend/package.json` (test script includes reauth tests)

## Verification
- `cd backend && npm test` → 49/49 pass (incl. 13 reauth regression cases)
- `cd backend && npx tsc --noEmit` → clean

## Notes
Frontend still prompts for password on disable for credential users (unchanged). Passwordless clients that need step-up outside the 5-minute window should call `/passkey/reauth-options` then resubmit with `passkeyCredential` + `passkeySessionId`. No PR URL — worker publishes.

Implements Orchestrator ticket #3440.