### PR TITLE
[security-audit] GET /api/config still returns full secrets to any authenticated user

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/utils/config-secrets.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { csrfProtection } from "../security.js";
-import { requireAuth, requireAdmin } from "../auth/middleware.js";
+import { requireAdmin } from "../auth/middleware.js";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendNotificationToUser } from '../push-notifications.js';
 import { translateNotification } from '../i18n-backend.js';
@@ -16,6 +16,10 @@ import { getAllUsers } from '../database-users.js';
 import { DATA_DIR, reloadConfig, getLogLevel } from "../config.js";
 import { sendTestEmail } from "../email.js";
 import { initLogger } from '../utils/logger.js';
+import {
+  maskSensitiveFields,
+  restoreSensitiveFields,
+} from "../utils/config-secrets.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -102,16 +106,14 @@ router.use(csrfProtection);
 
 /**
  * GET /api/config
- * Get current configuration (excluding sensitive fields)
+ * Admin only. Sensitive secrets are masked (not returned in cleartext).
  */
-router.get("/", requireAuth, (req, res) => {
+router.get("/", requireAdmin, (req, res) => {
   try {
     const configData = fs.readFileSync(CONFIG_PATH, "utf8");
     const config = JSON.parse(configData);
 
-    // Return full config for admin to edit
-    // (sensitive fields will be masked on frontend if needed)
-    res.json(config);
+    res.json(maskSensitiveFields(config));
   } catch (err) {
     error("[Config] Failed to read config:", err);
     res.status(500).json({ error: "Failed to read configuration" });
@@ -185,6 +187,9 @@ router.put("/", requireAdmin, express.json(), async (req, res) => {
       ...currentConfig,
       ...newConfig,
     };
+
+    // Do not wipe secrets when the client re-sends mask tokens from GET
+    restoreSensitiveFields(updatedConfig, currentConfig);
 
     // Write updated config back to file
     fs.writeFileSync(

--- a/backend/src/utils/config-secrets.test.ts
+++ b/backend/src/utils/config-secrets.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SECRET_MASK,
+  maskSensitiveFields,
+  restoreSensitiveFields,
+} from "./config-secrets.js";
+
+const sampleConfig = () => ({
+  environment: {
+    auth: {
+      google: {
+        enabled: true,
+        clientId: "public-client-id",
+        clientSecret: "google-secret-value",
+      },
+      sessionSecret: "session-secret-value",
+      authorizedEmails: ["admin@example.com"],
+    },
+  },
+  email: {
+    enabled: true,
+    smtp: {
+      host: "smtp.example.com",
+      port: 587,
+      auth: {
+        user: "smtp-user",
+        pass: "smtp-password",
+      },
+    },
+  },
+  openai: {
+    apiKey: "sk-test-openai-key",
+  },
+  pushNotifications: {
+    enabled: true,
+    vapidPublicKey: "vapid-public",
+    vapidPrivateKey: "vapid-private-secret",
+  },
+  analytics: {
+    openobserve: {
+      enabled: true,
+      endpoint: "https://oo.example.com",
+      username: "oo-user",
+      password: "oo-password",
+    },
+  },
+  branding: {
+    siteName: "Galleria",
+  },
+});
+
+test("maskSensitiveFields redacts known secrets and leaves non-secrets", () => {
+  const masked = maskSensitiveFields(sampleConfig());
+
+  assert.equal(masked.environment.auth.google.clientSecret, SECRET_MASK);
+  assert.equal(masked.environment.auth.sessionSecret, SECRET_MASK);
+  assert.equal(masked.email.smtp.auth.pass, SECRET_MASK);
+  assert.equal(masked.openai.apiKey, SECRET_MASK);
+  assert.equal(masked.pushNotifications.vapidPrivateKey, SECRET_MASK);
+  assert.equal(masked.analytics.openobserve.password, SECRET_MASK);
+
+  // Non-secrets preserved
+  assert.equal(masked.environment.auth.google.clientId, "public-client-id");
+  assert.equal(masked.email.smtp.auth.user, "smtp-user");
+  assert.equal(masked.pushNotifications.vapidPublicKey, "vapid-public");
+  assert.equal(masked.analytics.openobserve.username, "oo-user");
+  assert.equal(masked.branding.siteName, "Galleria");
+});
+
+test("maskSensitiveFields does not mutate the original object", () => {
+  const original = sampleConfig();
+  maskSensitiveFields(original);
+  assert.equal(original.openai.apiKey, "sk-test-openai-key");
+  assert.equal(original.environment.auth.sessionSecret, "session-secret-value");
+});
+
+test("maskSensitiveFields leaves empty secrets empty", () => {
+  const masked = maskSensitiveFields({
+    openai: { apiKey: "" },
+    environment: { auth: { sessionSecret: "", google: { clientSecret: "" } } },
+  });
+  assert.equal(masked.openai.apiKey, "");
+  assert.equal(masked.environment.auth.sessionSecret, "");
+  assert.equal(masked.environment.auth.google.clientSecret, "");
+});
+
+test("restoreSensitiveFields restores mask tokens from current config", () => {
+  const current = sampleConfig();
+  const incoming = maskSensitiveFields(current);
+  // Simulate admin toggling a non-secret
+  incoming.branding.siteName = "Updated";
+
+  restoreSensitiveFields(incoming, current);
+
+  assert.equal(incoming.environment.auth.sessionSecret, "session-secret-value");
+  assert.equal(incoming.environment.auth.google.clientSecret, "google-secret-value");
+  assert.equal(incoming.email.smtp.auth.pass, "smtp-password");
+  assert.equal(incoming.openai.apiKey, "sk-test-openai-key");
+  assert.equal(incoming.pushNotifications.vapidPrivateKey, "vapid-private-secret");
+  assert.equal(incoming.analytics.openobserve.password, "oo-password");
+  assert.equal(incoming.branding.siteName, "Updated");
+});
+
+test("restoreSensitiveFields allows intentional clear via empty string", () => {
+  const current = sampleConfig();
+  const incoming = maskSensitiveFields(current);
+  incoming.openai.apiKey = "";
+
+  restoreSensitiveFields(incoming, current);
+
+  assert.equal(incoming.openai.apiKey, "");
+  assert.equal(incoming.environment.auth.sessionSecret, "session-secret-value");
+});
+
+test("restoreSensitiveFields accepts a new secret value", () => {
+  const current = sampleConfig();
+  const incoming = maskSensitiveFields(current);
+  incoming.openai.apiKey = "sk-new-key";
+
+  restoreSensitiveFields(incoming, current);
+
+  assert.equal(incoming.openai.apiKey, "sk-new-key");
+});

--- a/backend/src/utils/config-secrets.ts
+++ b/backend/src/utils/config-secrets.ts
@@ -1,0 +1,88 @@
+/**
+ * Mask / restore sensitive config fields for the config API.
+ * GET responses never re-emit raw secrets; PUT restores mask tokens from disk.
+ */
+
+/** Placeholder written for non-empty secrets on GET. Presence checks stay truthy. */
+export const SECRET_MASK = "********";
+
+/** Leaf keys treated as secrets (walked recursively). */
+const SENSITIVE_KEYS = new Set([
+  "clientSecret",
+  "sessionSecret",
+  "password",
+  "apiKey",
+  "vapidPrivateKey",
+  "pass",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function maskObject(obj: Record<string, unknown>): void {
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (SENSITIVE_KEYS.has(key) && typeof val === "string" && val.length > 0) {
+      obj[key] = SECRET_MASK;
+    } else if (isPlainObject(val)) {
+      maskObject(val);
+    } else if (Array.isArray(val)) {
+      for (const item of val) {
+        if (isPlainObject(item)) {
+          maskObject(item);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Deep-clone config and replace non-empty sensitive string fields with SECRET_MASK.
+ */
+export function maskSensitiveFields<T>(config: T): T {
+  if (config === null || config === undefined) {
+    return config;
+  }
+  const clone = structuredClone(config) as T;
+  if (isPlainObject(clone)) {
+    maskObject(clone);
+  }
+  return clone;
+}
+
+/**
+ * When a sensitive field is still SECRET_MASK, keep the on-disk value so a
+ * round-trip save does not wipe secrets the admin did not re-enter.
+ * Empty strings are left alone (intentional clear).
+ */
+export function restoreSensitiveFields(
+  incoming: unknown,
+  current: unknown
+): void {
+  if (!isPlainObject(incoming) || !isPlainObject(current)) {
+    return;
+  }
+
+  for (const key of Object.keys(incoming)) {
+    const inVal = incoming[key];
+    const curVal = current[key];
+
+    if (SENSITIVE_KEYS.has(key) && typeof inVal === "string") {
+      if (inVal === SECRET_MASK && typeof curVal === "string") {
+        incoming[key] = curVal;
+      }
+      continue;
+    }
+
+    if (isPlainObject(inVal) && isPlainObject(curVal)) {
+      restoreSensitiveFields(inVal, curVal);
+    } else if (Array.isArray(inVal) && Array.isArray(curVal)) {
+      for (let i = 0; i < inVal.length; i++) {
+        if (isPlainObject(inVal[i]) && isPlainObject(curVal[i])) {
+          restoreSensitiveFields(inVal[i], curVal[i]);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Ticket 3438 — GET /api/config secrets

## What changed

`GET /api/config` was gated only by `requireAuth` and returned raw `config.json`, so any logged-in viewer could read session secrets, OAuth client secrets, SMTP passwords, OpenAI keys, VAPID private keys, and OpenObserve passwords (Worf finding; regression of #883-style hardening).

Fix:
1. Gate GET with `requireAdmin`.
2. Return `maskSensitiveFields(config)` — non-empty secret leaf keys become `********` so presence checks stay truthy without leaking values.
3. On PUT, `restoreSensitiveFields` rehydrates mask tokens from on-disk config so admin save-without-retype does not wipe secrets; empty string still clears intentionally.

## Files

- `backend/src/routes/config.ts` — requireAdmin + mask on GET; restore on PUT
- `backend/src/utils/config-secrets.ts` — mask/restore helpers
- `backend/src/utils/config-secrets.test.ts` — unit coverage
- `backend/package.json` — include new test in `npm test`

## Verification

- `npm ci --cache /tmp/npm-cache-galleria-3438` (default cache had root-owned files)
- `cd backend && npm test` — 42 pass, 0 fail (includes 6 config-secrets tests)

## Notes

- Workers own commit/PR; source left unstaged in worktree.
- Managers no longer receive full config via GET (admin-only). Album AI title button that probed `config.openai.apiKey` will only light for admins; generation API still uses server-side key for managers.

Implements Orchestrator ticket #3438.