### PR TITLE
Batch merge #413: #3445, #3439, #3443, #3441, #3442, #3440, #3444, #3438

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/utils/config-secrets.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/auth/passkeys-auth-options.test.ts
+++ b/backend/src/auth/passkeys-auth-options.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Minimal RP env so generateAuthenticationOptions does not need full app config.
+process.env.RP_ID = process.env.RP_ID || 'localhost';
+process.env.ORIGIN = process.env.ORIGIN || 'http://localhost:5173';
+
+const { generatePasskeyAuthenticationOptions } = await import('./passkeys.js');
+
+test('generatePasskeyAuthenticationOptions never populates allowCredentials', async () => {
+  const withPasskeys = await generatePasskeyAuthenticationOptions([
+    {
+      id: 1,
+      name: 'yubikey',
+      credentialID: 'AAAA',
+      transports: ['usb'],
+    },
+    {
+      id: 2,
+      name: 'phone',
+      credentialID: 'BBBB',
+      transports: ['internal'],
+    },
+  ]);
+  const without = await generatePasskeyAuthenticationOptions([]);
+  const omitted = await generatePasskeyAuthenticationOptions();
+
+  for (const options of [withPasskeys, without, omitted]) {
+    assert.ok(options.challenge, 'challenge present');
+    assert.ok(options.rpId || options.rpID, 'rp id present');
+    // Empty list or absent — never a list of real credential IDs
+    const allow = (options as { allowCredentials?: unknown[] }).allowCredentials;
+    if (allow !== undefined) {
+      assert.deepEqual(allow, []);
+    }
+  }
+
+  // Shape must not depend on whether fake passkeys were supplied
+  assert.equal(
+    (withPasskeys as { allowCredentials?: unknown[] }).allowCredentials?.length ?? 0,
+    (without as { allowCredentials?: unknown[] }).allowCredentials?.length ?? 0
+  );
+  // Must not echo caller-supplied credential IDs
+  const serialized = JSON.stringify(withPasskeys);
+  assert.equal(serialized.includes('AAAA'), false);
+  assert.equal(serialized.includes('BBBB'), false);
+});

--- a/backend/src/auth/passkeys.ts
+++ b/backend/src/auth/passkeys.ts
@@ -128,21 +128,27 @@ export async function verifyPasskeyRegistration(
 }
 
 /**
- * Generate options for passkey authentication
+ * Generate options for passkey authentication.
+ *
+ * Always discoverable: allowCredentials is intentionally empty regardless of
+ * any caller-supplied passkeys. Populating allowCredentials from a public
+ * email lookup enables account/credential enumeration (ticket #3444).
+ *
+ * @param _existingPasskeys unused — kept for call-site compatibility
  */
 export async function generatePasskeyAuthenticationOptions(
-  existingPasskeys: any[] = []
+  _existingPasskeys: any[] = []
 ) {
   const { rpID } = getRPConfig();
 
   debug("[Passkeys] Generating auth options for RP:", rpID);
 
-  // Don't specify allowCredentials - this lets password managers (like 1Password)
-  // automatically offer their stored passkeys without browser showing generic options
+  // Empty allowCredentials: discoverable credentials only. Password managers
+  // (e.g. 1Password) offer stored passkeys without server-side credential lists.
   const options = await generateAuthenticationOptions({
     rpID,
     userVerification: "preferred",
-    // timeout: 60000, // 60 seconds
+    allowCredentials: [],
   });
 
   return options;

--- a/backend/src/auth/reauth.test.ts
+++ b/backend/src/auth/reauth.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  REAUTH_WINDOW_MS,
+  isRecentAuth,
+  planSensitiveReauth,
+  userHasPasskeys,
+  userHasPassword,
+} from './reauth.js';
+
+test('userHasPassword treats null/empty as absent', () => {
+  assert.equal(userHasPassword({ password_hash: null }), false);
+  assert.equal(userHasPassword({ password_hash: '' }), false);
+  assert.equal(userHasPassword({ password_hash: 'hash' }), true);
+});
+
+test('userHasPasskeys requires non-empty array', () => {
+  assert.equal(userHasPasskeys({ passkeys: null }), false);
+  assert.equal(userHasPasskeys({ passkeys: [] }), false);
+  assert.equal(userHasPasskeys({ passkeys: [{ id: '1' }] }), true);
+});
+
+test('isRecentAuth fails closed on missing timestamps', () => {
+  const now = 1_000_000;
+  assert.equal(isRecentAuth(undefined, now), false);
+  assert.equal(isRecentAuth(null, now), false);
+  assert.equal(isRecentAuth(Number.NaN, now), false);
+});
+
+test('isRecentAuth accepts only within window', () => {
+  const now = 1_000_000;
+  assert.equal(isRecentAuth(now, now), true);
+  assert.equal(isRecentAuth(now - REAUTH_WINDOW_MS, now), true);
+  assert.equal(isRecentAuth(now - REAUTH_WINDOW_MS - 1, now), false);
+  assert.equal(isRecentAuth(now + 1, now), false); // future clock skew rejected
+});
+
+test('password account requires password; session alone never enough', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: false,
+    sessionAuthenticatedAt: Date.now(),
+  });
+  assert.equal(plan.action, 'reject');
+  if (plan.action === 'reject') {
+    assert.equal(plan.code, 'password_required');
+    assert.ok(plan.availableMethods.includes('password'));
+    assert.ok(!plan.availableMethods.includes('recent_login'));
+  }
+});
+
+test('password account with password plans verify_password', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: false,
+    password: 'secret',
+  });
+  assert.deepEqual(plan, { action: 'verify_password', password: 'secret' });
+});
+
+test('password account may use passkey when both registered', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: true,
+    passkeyCredential: { id: 'cred' },
+    passkeySessionId: 'sid-1',
+  });
+  assert.equal(plan.action, 'verify_passkey');
+  if (plan.action === 'verify_passkey') {
+    assert.equal(plan.sessionId, 'sid-1');
+  }
+});
+
+test('passwordless passkey user without proof is rejected (regression #3440)', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: true,
+    // stale / missing session auth time
+    sessionAuthenticatedAt: Date.now() - REAUTH_WINDOW_MS - 10_000,
+  });
+  assert.equal(plan.action, 'reject');
+  if (plan.action === 'reject') {
+    assert.equal(plan.code, 'passkey_reauth_required');
+  }
+});
+
+test('passwordless passkey user accepts fresh passkey assertion', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: true,
+    passkeyCredential: { id: 'cred' },
+    passkeySessionId: 'reauth-1',
+  });
+  assert.equal(plan.action, 'verify_passkey');
+});
+
+test('passwordless passkey user accepts recent login', () => {
+  const now = 5_000_000;
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: true,
+    sessionAuthenticatedAt: now - 60_000,
+    now,
+  });
+  assert.equal(plan.action, 'accept_recent_login');
+});
+
+test('OAuth-only without recent login is rejected (session theft path)', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: false,
+    sessionAuthenticatedAt: undefined,
+  });
+  assert.equal(plan.action, 'reject');
+  if (plan.action === 'reject') {
+    assert.equal(plan.code, 'reauth_required');
+    assert.deepEqual(plan.availableMethods, ['recent_login']);
+  }
+});
+
+test('OAuth-only with recent login is accepted', () => {
+  const now = 9_000_000;
+  const plan = planSensitiveReauth({
+    hasPassword: false,
+    hasPasskeys: false,
+    sessionAuthenticatedAt: now - 30_000,
+    now,
+  });
+  assert.equal(plan.action, 'accept_recent_login');
+});
+
+test('empty password string does not count as provided', () => {
+  const plan = planSensitiveReauth({
+    hasPassword: true,
+    hasPasskeys: false,
+    password: '',
+  });
+  assert.equal(plan.action, 'reject');
+});

--- a/backend/src/auth/reauth.ts
+++ b/backend/src/auth/reauth.ts
@@ -1,0 +1,146 @@
+/**
+ * Step-up re-authentication for sensitive account actions (MFA disable, backup codes).
+ *
+ * Rules (ticket #3440 / #536 class):
+ * - Password present → must prove password (session alone is never enough)
+ * - Passwordless with passkeys → fresh passkey assertion OR recent-login window
+ * - OAuth-only (no password, no passkey) → recent-login window only
+ */
+
+/** Max age of session.authenticatedAt accepted as "recent login" proof. */
+export const REAUTH_WINDOW_MS = 5 * 60 * 1000;
+
+export type ReauthMethod = 'password' | 'passkey' | 'recent_login';
+
+export type ReauthPlan =
+  | { action: 'verify_password'; password: string }
+  | { action: 'verify_passkey'; credential: unknown; sessionId: string }
+  | { action: 'accept_recent_login' }
+  | {
+      action: 'reject';
+      status: number;
+      error: string;
+      code: string;
+      availableMethods: ReauthMethod[];
+    };
+
+export function userHasPassword(user: { password_hash?: string | null }): boolean {
+  return typeof user.password_hash === 'string' && user.password_hash.length > 0;
+}
+
+export function userHasPasskeys(user: { passkeys?: unknown[] | null }): boolean {
+  return Array.isArray(user.passkeys) && user.passkeys.length > 0;
+}
+
+/**
+ * True when authenticatedAt is a finite timestamp within the reauth window of `now`.
+ * Missing / non-finite timestamps fail closed (not recent).
+ */
+export function isRecentAuth(
+  authenticatedAt: number | null | undefined,
+  now: number = Date.now(),
+  windowMs: number = REAUTH_WINDOW_MS
+): boolean {
+  if (authenticatedAt == null || !Number.isFinite(authenticatedAt)) {
+    return false;
+  }
+  const age = now - authenticatedAt;
+  return age >= 0 && age <= windowMs;
+}
+
+function availableMethods(hasPassword: boolean, hasPasskeys: boolean): ReauthMethod[] {
+  const methods: ReauthMethod[] = [];
+  if (hasPassword) methods.push('password');
+  if (hasPasskeys) methods.push('passkey');
+  if (!hasPassword) methods.push('recent_login');
+  return methods;
+}
+
+/**
+ * Decide how to re-prove identity for a sensitive action.
+ * Does not perform crypto; callers verify password/passkey after this plan.
+ */
+export function planSensitiveReauth(input: {
+  hasPassword: boolean;
+  hasPasskeys: boolean;
+  password?: string | null;
+  passkeyCredential?: unknown;
+  passkeySessionId?: string | null;
+  sessionAuthenticatedAt?: number | null;
+  now?: number;
+  windowMs?: number;
+}): ReauthPlan {
+  const {
+    hasPassword,
+    hasPasskeys,
+    password,
+    passkeyCredential,
+    passkeySessionId,
+    sessionAuthenticatedAt,
+    now = Date.now(),
+    windowMs = REAUTH_WINDOW_MS,
+  } = input;
+
+  const methods = availableMethods(hasPassword, hasPasskeys);
+  const passwordProvided = typeof password === 'string' && password.length > 0;
+  const passkeyProvided =
+    passkeyCredential != null &&
+    typeof passkeySessionId === 'string' &&
+    passkeySessionId.length > 0;
+
+  // Password accounts: always require password proof (session theft must not disable MFA).
+  if (hasPassword) {
+    if (passwordProvided) {
+      return { action: 'verify_password', password: password as string };
+    }
+    // Optional: allow passkey step-up for hybrid password+passkey accounts.
+    if (passkeyProvided && hasPasskeys) {
+      return {
+        action: 'verify_passkey',
+        credential: passkeyCredential,
+        sessionId: passkeySessionId as string,
+      };
+    }
+    return {
+      action: 'reject',
+      status: 401,
+      error: 'Password required',
+      code: 'password_required',
+      availableMethods: methods,
+    };
+  }
+
+  // Passwordless with passkeys: assertion or recent login.
+  if (hasPasskeys) {
+    if (passkeyProvided) {
+      return {
+        action: 'verify_passkey',
+        credential: passkeyCredential,
+        sessionId: passkeySessionId as string,
+      };
+    }
+    if (isRecentAuth(sessionAuthenticatedAt, now, windowMs)) {
+      return { action: 'accept_recent_login' };
+    }
+    return {
+      action: 'reject',
+      status: 401,
+      error: 'Re-authentication required',
+      code: 'passkey_reauth_required',
+      availableMethods: methods,
+    };
+  }
+
+  // OAuth-only: recent login only (no interactive second factor registered).
+  if (isRecentAuth(sessionAuthenticatedAt, now, windowMs)) {
+    return { action: 'accept_recent_login' };
+  }
+
+  return {
+    action: 'reject',
+    status: 401,
+    error: 'Re-authentication required. Sign in again to continue.',
+    code: 'reauth_required',
+    availableMethods: methods,
+  };
+}

--- a/backend/src/config.origin-allowed.test.ts
+++ b/backend/src/config.origin-allowed.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getAllowedOrigins, getConfigExists, isOriginAllowed } from './config.js';
+
+test('allows exact origins from getAllowedOrigins', () => {
+  const allowed = getAllowedOrigins();
+  assert.ok(allowed.length > 0, 'expected at least localhost defaults');
+  for (const origin of allowed) {
+    assert.equal(isOriginAllowed(origin), true, origin);
+  }
+});
+
+test('allows localhost and 127.0.0.1 on any port', () => {
+  assert.equal(isOriginAllowed('http://localhost:9999'), true);
+  assert.equal(isOriginAllowed('http://127.0.0.1:5173'), true);
+});
+
+test('allows IPv4 Docker/Unraid ports 3000 and 3001 only', () => {
+  assert.equal(isOriginAllowed('http://192.168.1.50:3000'), true);
+  assert.equal(isOriginAllowed('http://10.0.0.2:3001'), true);
+  assert.equal(isOriginAllowed('http://192.168.1.50:8080'), false);
+});
+
+test('rejects unlisted third-party origins (CORS bypass class)', () => {
+  // HTTP third-party never passes (OOBE only opens https when config is missing)
+  assert.equal(isOriginAllowed('http://evil.example'), false);
+  assert.equal(isOriginAllowed('http://attacker.example.com'), false);
+  assert.equal(isOriginAllowed('http://evil.example:3000'), false);
+
+  if (getConfigExists()) {
+    assert.equal(isOriginAllowed('https://evil.example'), false);
+    assert.equal(isOriginAllowed('https://attacker.example.com'), false);
+  } else {
+    // Matches global server CORS: OOBE allows any HTTPS origin during setup
+    assert.equal(isOriginAllowed('https://evil.example'), true);
+  }
+});
+
+test('rejects missing/empty origin', () => {
+  assert.equal(isOriginAllowed(undefined), false);
+  assert.equal(isOriginAllowed(null), false);
+  assert.equal(isOriginAllowed(''), false);
+});
+
+test('rejects malformed origin URLs', () => {
+  assert.equal(isOriginAllowed('not-a-url'), false);
+});

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -207,6 +207,49 @@ export function getAllowedOrigins(): string[] {
   return uniqueOrigins;
 }
 
+/**
+ * Whether a request Origin may be reflected with Access-Control-Allow-Credentials.
+ * Mirrors the global CORS origin callback in server.ts so route-level headers
+ * cannot bypass the allowlist (credentialed ACAO must never be set for unlisted origins).
+ */
+export function isOriginAllowed(origin: string | undefined | null): boolean {
+  if (!origin) {
+    return false;
+  }
+
+  // During OOBE (setup mode), allow any HTTPS origin — same as server CORS
+  if (!getConfigExists() && origin.startsWith("https://")) {
+    return true;
+  }
+
+  const allowedOrigins = getAllowedOrigins();
+  if (allowedOrigins.indexOf(origin) !== -1) {
+    return true;
+  }
+
+  try {
+    const url = new URL(origin);
+    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+      return true;
+    }
+
+    // Docker / Unraid direct access: any IPv4 on ports 3000 or 3001
+    const port = url.port
+      ? parseInt(url.port, 10)
+      : url.protocol === "https:"
+        ? 443
+        : 80;
+    const ipPattern = /^\d+\.\d+\.\d+\.\d+$/;
+    if (ipPattern.test(url.hostname) && (port === 3000 || port === 3001)) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
 // Export constants
 export const PORT = process.env.PORT
   ? parseInt(process.env.PORT)

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -1863,13 +1863,52 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
       res.status(400).json({ error: 'No thumbnail file uploaded' });
       return;
     }
+
+    // Validate inputs to prevent directory traversal (mirror update-thumbnail)
+    const sanitizedAlbumName = sanitizeName(albumName);
+    if (!sanitizedAlbumName) {
+      unlinkTempUpload(req.file.path);
+      res.status(400).json({ error: 'Invalid album name' });
+      return;
+    }
+
+    // Basic security check for filename - no transformation (exact disk name)
+    if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      unlinkTempUpload(req.file.path);
+      res.status(400).json({ error: 'Invalid filename' });
+      return;
+    }
+    const sanitizedFilename = filename;
     
     const appRoot = req.app.get('appRoot');
     const dataDir = process.env.DATA_DIR || path.join(appRoot, 'data');
-    const optimizedDir = path.join(dataDir, 'optimized');
+    const optimizedDir = path.resolve(path.join(dataDir, 'optimized'));
+    const jpgName = sanitizedFilename.replace(/\.[^.]+$/, '.jpg');
+
+    const thumbnailPath = path.resolve(optimizedDir, 'thumbnail', sanitizedAlbumName, jpgName);
+    const modalPath = path.resolve(optimizedDir, 'modal', sanitizedAlbumName, jpgName);
+
+    // Reject if resolved paths escape optimizedDir
+    for (const resolved of [thumbnailPath, modalPath]) {
+      const relative = path.relative(optimizedDir, resolved);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        unlinkTempUpload(req.file.path);
+        res.status(400).json({ error: 'Invalid path' });
+        return;
+      }
+    }
+
+    // Ensure output directories exist (same as update-thumbnail)
+    const thumbnailDir = path.dirname(thumbnailPath);
+    const modalDir = path.dirname(modalPath);
+    if (!fs.existsSync(thumbnailDir)) {
+      fs.mkdirSync(thumbnailDir, { recursive: true });
+    }
+    if (!fs.existsSync(modalDir)) {
+      fs.mkdirSync(modalDir, { recursive: true });
+    }
     
     // Generate thumbnail (512px)
-    const thumbnailPath = path.join(optimizedDir, 'thumbnail', albumName, filename.replace(/\.[^.]+$/, '.jpg'));
     await sharp(req.file.path)
       .resize(512, 512, { 
         fit: 'inside',
@@ -1879,7 +1918,6 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
       .toFile(thumbnailPath);
     
     // Generate modal preview (2048px)
-    const modalPath = path.join(optimizedDir, 'modal', albumName, filename.replace(/\.[^.]+$/, '.jpg'));
     await sharp(req.file.path)
       .resize(2048, 2048, { 
         fit: 'inside',
@@ -1891,13 +1929,13 @@ router.post('/:albumName/video/:filename/upload-thumbnail', requireManager, uplo
     // Clean up temporary file
     unlinkTempUpload(req.file.path);
     
-    info(`[VideoThumbnail] Uploaded custom thumbnail for ${albumName}/${filename}`);
+    info(`[VideoThumbnail] Uploaded custom thumbnail for ${sanitizedAlbumName}/${sanitizedFilename}`);
     
     // Regenerate static JSON to reflect thumbnail update
     try {
       info(`[VideoThumbnail] Regenerating static JSON after thumbnail upload`);
       generateStaticJSONFiles(appRoot);
-      invalidateAlbumCache(albumName);
+      invalidateAlbumCache(sanitizedAlbumName);
     } catch (err) {
       error('[VideoThumbnail] Failed to regenerate static JSON:', err);
     }

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1248,36 +1248,16 @@ router.post('/passkey/register-verify', requireAuth, async (req: Request, res: R
 });
 
 /**
- * Get authentication options for passkey login
+ * Get authentication options for passkey login.
+ *
+ * Public endpoint: always returns discoverable (empty allowCredentials) options
+ * with a constant shape. Never looks up users by email — that would enable
+ * account enumeration and credential-ID harvest for phishing.
  */
 router.post('/passkey/auth-options', async (req: Request, res: Response) => {
   try {
-    const { email } = req.body;
-    
-    // If email provided, get user's passkeys
-    let passkeys: any[] = [];
-    if (email) {
-      const user = getUserByEmail(email);
-      if (user && user.passkeys) {
-        passkeys = user.passkeys;
-        info('[Passkey Auth] Found user with passkeys:', {
-          email,
-          passkeyCount: passkeys.length,
-          passkeys: passkeys.map(pk => ({
-            id: pk.id,
-            name: pk.name,
-            credentialIDLength: pk.credentialID?.length,
-            transports: pk.transports
-          }))
-        });
-      } else {
-        info('[Passkey Auth] User not found or has no passkeys:', email);
-      }
-    } else {
-      info('[Passkey Auth] No email provided, returning empty allowCredentials');
-    }
-
-    const options = await generatePasskeyAuthenticationOptions(passkeys);
+    // Ignore email/body for enumeration resistance; client may still send email.
+    const options = await generatePasskeyAuthenticationOptions([]);
 
     // Store challenge
     const sessionId = crypto.randomUUID();

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -619,16 +619,11 @@ router.post('/password-reset/request', async (req: Request, res: Response) => {
 
     const user = getUserByEmail(email);
 
-    // Don't reveal if user exists or not (security best practice)
-    if (!user) {
+    // Uniform response for unknown emails and MFA accounts — do not reveal
+    // registration or MFA status. Self-service reset is only issued for
+    // non-MFA accounts; MFA recovery is via authenticated admin paths.
+    if (!user || user.mfa_enabled) {
       return res.json({ success: true, message: 'If the email exists, a password reset link has been sent' });
-    }
-
-    // Only allow password reset if user doesn't have MFA enabled
-    if (user.mfa_enabled) {
-      return res.status(400).json({ 
-        error: 'Password reset not available for accounts with MFA enabled. Contact an administrator for assistance.' 
-      });
     }
 
     // Generate reset token

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -1472,8 +1472,9 @@ router.delete('/passkey/:id', requireAuth, async (req: Request, res: Response) =
 
 /**
  * List all users (admin only)
+ * Does not return invite_token — use GET /users/:userId/invite-link for copy-link.
  */
-router.get('/users', requireAuth, (req: Request, res: Response) => {
+router.get('/users', requireAdmin, (req: Request, res: Response) => {
   try {
     const users = getAllUsers();
     
@@ -1481,7 +1482,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
     const sanitizedUsers = users.map((user: User) => {
       // Determine display status based on user state
       let displayStatus = null;
-      let inviteToken = null;
       
       if (user.status === 'invited') {
         // Check if invite has expired
@@ -1495,9 +1495,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         } else {
           displayStatus = 'invited';
         }
-        
-        // Include invite token for invited/expired users (needed for copy link functionality)
-        inviteToken = user.invite_token;
       }
       
       return {
@@ -1510,7 +1507,6 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
         passkey_count: user.passkeys?.length || 0,
         is_active: user.is_active,
         status: displayStatus, // Only show status if invited or expired
-        invite_token: inviteToken, // Include for invited users
         created_at: user.created_at,
         last_login_at: user.last_login_at,
       };
@@ -1520,6 +1516,36 @@ router.get('/users', requireAuth, (req: Request, res: Response) => {
   } catch (err) {
     error('[AuthExtended] List users error:', err);
     res.status(500).json({ error: 'Failed to list users' });
+  }
+});
+
+/**
+ * Get invite URL for an invited user (admin only — copy-link; never bulk-list tokens)
+ */
+router.get('/users/:userId/invite-link', requireAdmin, (req: Request, res: Response) => {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    if (Number.isNaN(userId)) {
+      return res.status(400).json({ error: 'Invalid user id' });
+    }
+
+    const user = getUserById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (user.status !== 'invited' && user.status !== 'invite_expired') {
+      return res.status(400).json({ error: 'User has no pending invitation' });
+    }
+
+    if (!user.invite_token) {
+      return res.status(404).json({ error: 'Invitation token not found' });
+    }
+
+    res.json({ inviteUrl: generateInvitationUrl(user.invite_token) });
+  } catch (err) {
+    error('[AuthExtended] Get invite link error:', err);
+    res.status(500).json({ error: 'Failed to get invitation link' });
   }
 });
 

--- a/backend/src/routes/auth-extended.ts
+++ b/backend/src/routes/auth-extended.ts
@@ -43,6 +43,11 @@ import {
   generatePasskeyAuthenticationOptions,
   verifyPasskeyAuthentication,
 } from '../auth/passkeys.js';
+import {
+  planSensitiveReauth,
+  userHasPasskeys,
+  userHasPassword,
+} from '../auth/reauth.js';
 import crypto from 'crypto';
 import { sendInvitationEmail, sendPasswordResetEmail, isEmailServiceEnabled, generateInvitationUrl } from '../email.js';
 import { getCurrentConfig, reloadConfig } from '../config.js';
@@ -51,6 +56,97 @@ import { translateNotification } from '../i18n-backend.js';
 import { destroySessionsForUser } from '../auth/session-invalidation.js';
 
 const router = Router();
+
+/**
+ * Step-up re-auth for MFA disable / backup-code mint.
+ * Password when present; else passkey assertion or recent-login window.
+ * Returns null on success, or an Express response already sent.
+ */
+async function requireSensitiveReauth(
+  req: Request,
+  res: Response,
+  user: User
+): Promise<true | null> {
+  const {
+    password,
+    passkeyCredential,
+    passkeySessionId,
+    // alternate names clients may send
+    credential,
+    sessionId,
+  } = req.body || {};
+
+  const plan = planSensitiveReauth({
+    hasPassword: userHasPassword(user),
+    hasPasskeys: userHasPasskeys(user),
+    password,
+    passkeyCredential: passkeyCredential ?? credential,
+    passkeySessionId: passkeySessionId ?? sessionId,
+    sessionAuthenticatedAt: (req.session as any)?.authenticatedAt,
+  });
+
+  if (plan.action === 'reject') {
+    res.status(plan.status).json({
+      error: plan.error,
+      code: plan.code,
+      availableMethods: plan.availableMethods,
+    });
+    return null;
+  }
+
+  if (plan.action === 'accept_recent_login') {
+    return true;
+  }
+
+  if (plan.action === 'verify_password') {
+    if (!verifyPassword(user, plan.password)) {
+      res.status(401).json({ error: 'Invalid password', code: 'invalid_password' });
+      return null;
+    }
+    return true;
+  }
+
+  // verify_passkey
+  const challengeKey = `passkey-reauth-${plan.sessionId}`;
+  const stored = challenges.get(challengeKey);
+  if (!stored || stored.userId !== user.id || stored.expires < Date.now()) {
+    res.status(400).json({
+      error: 'Invalid or expired passkey reauth challenge',
+      code: 'passkey_challenge_invalid',
+    });
+    return null;
+  }
+
+  const credentialPayload = plan.credential as { id?: string };
+  if (!credentialPayload?.id) {
+    res.status(400).json({ error: 'Missing passkey credential', code: 'passkey_required' });
+    return null;
+  }
+
+  const result = getPasskeyByCredentialId(credentialPayload.id);
+  if (!result || result.user.id !== user.id) {
+    res.status(400).json({ error: 'Passkey not found', code: 'passkey_not_found' });
+    return null;
+  }
+
+  const verification = await verifyPasskeyAuthentication(
+    plan.credential as any,
+    stored.challenge,
+    result.passkey.credentialPublicKey,
+    result.passkey.counter
+  );
+
+  if (!verification.verified) {
+    res.status(401).json({ error: 'Passkey verification failed', code: 'passkey_invalid' });
+    return null;
+  }
+
+  updatePasskeyCounter(user.id, result.passkey.id, verification.authenticationInfo.newCounter);
+  challenges.delete(challengeKey);
+  // Refresh authenticatedAt so subsequent sensitive ops in-window succeed without re-prompt.
+  (req.session as any).authenticatedAt = Date.now();
+  return true;
+}
 
 /**
  * Helper to send push notification to all admin users
@@ -258,6 +354,7 @@ router.post('/login', async (req: Request, res: Response) => {
       }
 
       (req.session as any).userId = user.id;
+      (req.session as any).authenticatedAt = Date.now();
       (req.session as any).user = {
         id: user.id,
         email: user.email,
@@ -1044,6 +1141,7 @@ router.post('/mfa/verify-setup', requireAuth, async (req: Request, res: Response
 
 /**
  * Disable MFA
+ * Requires step-up reauth: password if set, else passkey assertion or recent login.
  */
 router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => {
   try {
@@ -1051,16 +1149,15 @@ router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => 
     if (!userId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
-    const { password } = req.body;
 
     const user = getUserById(userId);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    // Verify password before disabling MFA
-    if (user.password_hash && !verifyPassword(user, password)) {
-      return res.status(401).json({ error: 'Invalid password' });
+    const reauthOk = await requireSensitiveReauth(req, res, user);
+    if (!reauthOk) {
+      return;
     }
 
     disableMFA(userId);
@@ -1093,6 +1190,7 @@ router.post('/mfa/disable', requireAuth, async (req: Request, res: Response) => 
 
 /**
  * Get new backup codes
+ * Requires step-up reauth: password if set, else passkey assertion or recent login.
  */
 router.post('/mfa/backup-codes', requireAuth, async (req: Request, res: Response) => {
   try {
@@ -1100,16 +1198,15 @@ router.post('/mfa/backup-codes', requireAuth, async (req: Request, res: Response
     if (!userId) {
       return res.status(401).json({ error: 'User not authenticated' });
     }
-    const { password } = req.body;
 
     const user = getUserById(userId);
     if (!user || !user.mfa_enabled) {
       return res.status(400).json({ error: 'MFA is not enabled' });
     }
 
-    // Verify password
-    if (user.password_hash && !verifyPassword(user, password)) {
-      return res.status(401).json({ error: 'Invalid password' });
+    const reauthOk = await requireSensitiveReauth(req, res, user);
+    if (!reauthOk) {
+      return;
     }
 
     // Generate new backup codes
@@ -1248,6 +1345,44 @@ router.post('/passkey/register-verify', requireAuth, async (req: Request, res: R
 });
 
 /**
+ * Generate passkey options for step-up reauth (sensitive actions while already logged in).
+ * Challenge is stored under passkey-reauth-${sessionId} and consumed by requireSensitiveReauth.
+ */
+router.post('/passkey/reauth-options', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const userId = getUserIdFromRequest(req);
+    if (!userId) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+
+    const user = getUserById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (!userHasPasskeys(user)) {
+      return res.status(400).json({
+        error: 'No passkeys registered',
+        code: 'no_passkeys',
+      });
+    }
+
+    const options = await generatePasskeyAuthenticationOptions(user.passkeys || []);
+    const sessionId = crypto.randomUUID();
+    challenges.set(`passkey-reauth-${sessionId}`, {
+      challenge: options.challenge,
+      userId,
+      expires: Date.now() + 5 * 60 * 1000,
+    });
+
+    res.json({ ...options, sessionId });
+  } catch (err) {
+    error('[AuthExtended] Passkey reauth options error:', err);
+    res.status(500).json({ error: 'Failed to generate reauth options' });
+  }
+});
+
+/**
  * Get authentication options for passkey login
  */
 router.post('/passkey/auth-options', async (req: Request, res: Response) => {
@@ -1347,6 +1482,7 @@ router.post('/passkey/auth-verify', async (req: Request, res: Response) => {
       }
 
       (req.session as any).userId = user.id;
+      (req.session as any).authenticatedAt = Date.now();
       (req.session as any).user = {
         id: user.id,
         email: user.email,

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -277,6 +277,9 @@ router.get(
           });
           return res.redirect(`${frontendUrl}/auth/error?reason=failed`);
         }
+
+        // Stamp for sensitive-action reauth window (MFA disable / backup codes)
+        (req.session as any).authenticatedAt = Date.now();
         
         // Explicitly save the session before redirecting
         req.session.save(async (err) => {

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -8,7 +8,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { csrfProtection } from "../security.js";
-import { requireAuth, requireAdmin } from "../auth/middleware.js";
+import { requireAdmin } from "../auth/middleware.js";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { sendNotificationToUser } from '../push-notifications.js';
 import { translateNotification } from '../i18n-backend.js';
@@ -16,6 +16,10 @@ import { getAllUsers } from '../database-users.js';
 import { DATA_DIR, reloadConfig, getLogLevel } from "../config.js";
 import { sendTestEmail } from "../email.js";
 import { initLogger } from '../utils/logger.js';
+import {
+  maskSensitiveFields,
+  restoreSensitiveFields,
+} from "../utils/config-secrets.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -102,16 +106,14 @@ router.use(csrfProtection);
 
 /**
  * GET /api/config
- * Get current configuration (excluding sensitive fields)
+ * Admin only. Sensitive secrets are masked (not returned in cleartext).
  */
-router.get("/", requireAuth, (req, res) => {
+router.get("/", requireAdmin, (req, res) => {
   try {
     const configData = fs.readFileSync(CONFIG_PATH, "utf8");
     const config = JSON.parse(configData);
 
-    // Return full config for admin to edit
-    // (sensitive fields will be masked on frontend if needed)
-    res.json(config);
+    res.json(maskSensitiveFields(config));
   } catch (err) {
     error("[Config] Failed to read config:", err);
     res.status(500).json({ error: "Failed to read configuration" });
@@ -185,6 +187,9 @@ router.put("/", requireAdmin, express.json(), async (req, res) => {
       ...currentConfig,
       ...newConfig,
     };
+
+    // Do not wipe secrets when the client re-sends mask tokens from GET
+    restoreSensitiveFields(updatedConfig, currentConfig);
 
     // Write updated config back to file
     fs.writeFileSync(

--- a/backend/src/routes/video.ts
+++ b/backend/src/routes/video.ts
@@ -10,8 +10,33 @@ import { error, info } from '../utils/logger.js';
 import { getAlbumState, getShareLinkBySecret, isShareLinkExpired } from '../database.js';
 import { requireAuth } from '../auth/middleware.js';
 import { isRequestAuthenticated } from '../utils/album-access.js';
+import { isOriginAllowed } from '../config.js';
 
 const router = Router();
+
+/**
+ * Reflect Origin only when it passes the global allowlist.
+ * Unconditional reflection + credentials bypassed server CORS (regression of #821).
+ */
+const setCredentialedCorsHeaders = (req: Request, res: Response): void => {
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && isOriginAllowed(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+};
+
+/** Same rules for writeHead() paths that cannot call setHeader after headers start. */
+const credentialedCorsHeaderRecord = (req: Request): Record<string, string> => {
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && isOriginAllowed(origin)) {
+    return {
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Credentials': 'true',
+    };
+  }
+  return {};
+};
 
 /**
  * Sanitize path components to prevent directory traversal
@@ -65,12 +90,7 @@ const appendKeyToPlaylistUris = (content: string, key: string): string => {
 const sendPlaylist = (req: Request, res: Response, playlistPath: string): void => {
   res.setHeader('Content-Type', 'application/vnd.apple.mpegurl');
   res.setHeader('Cache-Control', 'public, max-age=3600');
-
-  const origin = req.headers.origin;
-  if (origin) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-  }
+  setCredentialedCorsHeaders(req, res);
 
   const shareKey = getShareKeyFromQuery(req);
   if (shareKey) {
@@ -337,13 +357,7 @@ router.get("/:album/:filename/:resolution/:segment", async (req: Request, res: R
     // Set appropriate headers for MPEG-TS segments
     res.setHeader('Content-Type', 'video/mp2t');
     res.setHeader('Cache-Control', 'public, max-age=31536000'); // Cache segments for 1 year
-    
-    // Set CORS headers to allow credentials
-    const origin = req.headers.origin;
-    if (origin) {
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Access-Control-Allow-Credentials', 'true');
-    }
+    setCredentialedCorsHeaders(req, res);
 
     // Send the segment file
     res.sendFile(segmentPath);
@@ -485,8 +499,7 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
         'Accept-Ranges': 'bytes',
         'Content-Length': chunksize,
         'Content-Type': 'video/mp4',
-        'Access-Control-Allow-Origin': req.headers.origin || '*',
-        'Access-Control-Allow-Credentials': 'true',
+        ...credentialedCorsHeaderRecord(req),
       });
 
       file.pipe(res);
@@ -496,8 +509,7 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
         'Content-Length': fileSize,
         'Content-Type': 'video/mp4',
         'Accept-Ranges': 'bytes',
-        'Access-Control-Allow-Origin': req.headers.origin || '*',
-        'Access-Control-Allow-Credentials': 'true',
+        ...credentialedCorsHeaderRecord(req),
       });
 
       fs.createReadStream(rotatedVideoPath).pipe(res);

--- a/backend/src/security.ts
+++ b/backend/src/security.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import config, { getAllowedOrigins } from './config.js';
 import { info, warn, error, debug, verbose, trace } from './utils/logger.js';
+import { originsEqual } from './utils/origins-equal.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -181,8 +182,8 @@ export function csrfProtection(req: any, res: any, next: any) {
     // Get dynamic allowed origins (includes config.json values)
     const allowedOrigins = getAllowedOrigins();
     
-    // Check exact match first
-    let isAllowedOrigin = allowedOrigins.some((allowed: string) => origin.startsWith(allowed));
+    // Exact origin match (not startsWith — confusable subdomain bypass)
+    let isAllowedOrigin = allowedOrigins.some((allowed: string) => originsEqual(origin, allowed));
     
     // If not in allowed list, check for localhost
     if (!isAllowedOrigin) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -386,6 +386,9 @@ app.use("/api/", limiter);
 // Apply stricter rate limiting to authentication endpoints
 app.use("/api/auth-extended/login", authLimiter);
 app.use("/api/auth-extended/password-reset", authLimiter);
+// Public passkey login bootstrap — rate-limit by IP (ticket #3444 / #1038)
+app.use("/api/auth-extended/passkey/auth-options", authLimiter);
+app.use("/api/auth-extended/passkey/auth-verify", authLimiter);
 app.use("/api/auth/google", authLimiter);
 
 // Parse JSON request bodies with size limit

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -382,13 +382,27 @@ const authLimiter = rateLimit({
   skipSuccessfulRequests: true, // Don't count successful logins
 });
 
+// Passkey bootstrap routes always (or often) return 2xx with challenge material.
+// authLimiter's skipSuccessfulRequests would never increment on auth-options
+// (always 200) and under-count verify abuse — count every response by IP.
+const passkeyAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // Limit each IP to 10 requests per windowMs
+  message:
+    "Too many authentication attempts from this IP, please try again after 15 minutes.",
+  standardHeaders: true,
+  legacyHeaders: false,
+  // Count all outcomes — required for public challenge issuance
+  skipSuccessfulRequests: false,
+});
+
 app.use("/api/", limiter);
 // Apply stricter rate limiting to authentication endpoints
 app.use("/api/auth-extended/login", authLimiter);
 app.use("/api/auth-extended/password-reset", authLimiter);
-// Public passkey login bootstrap — rate-limit by IP (ticket #3444 / #1038)
-app.use("/api/auth-extended/passkey/auth-options", authLimiter);
-app.use("/api/auth-extended/passkey/auth-verify", authLimiter);
+// Public passkey login bootstrap — rate-limit by IP, all responses (ticket #3444)
+app.use("/api/auth-extended/passkey/auth-options", passkeyAuthLimiter);
+app.use("/api/auth-extended/passkey/auth-verify", passkeyAuthLimiter);
 app.use("/api/auth/google", authLimiter);
 
 // Parse JSON request bodies with size limit

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,8 +25,8 @@ import config, {
   PHOTOS_DIR,
   OPTIMIZED_DIR,
   DATA_DIR,
-  getAllowedOrigins,
   getConfigExists,
+  isOriginAllowed,
   RATE_LIMIT_WINDOW_MS,
   RATE_LIMIT_MAX_REQUESTS,
   getLogLevel,
@@ -277,55 +277,8 @@ app.use(
       // Allow requests with no origin (mobile apps, curl, etc.)
       if (!origin) return callback(null, true);
 
-      // Get current state (dynamic, updates after config changes)
-      const configExists = getConfigExists();
-      const allowedOrigins = getAllowedOrigins();
-
-      // During OOBE (setup mode), allow any HTTPS origin to enable setup from any domain
-      if (!configExists && origin.startsWith("https://")) {
-        trace(`[OOBE] Allowing CORS from: ${origin}`);
+      if (isOriginAllowed(origin)) {
         return callback(null, true);
-      }
-
-      // Check exact matches first
-      if (allowedOrigins.indexOf(origin) !== -1) {
-        callback(null, true);
-        return;
-      }
-
-      // Allow localhost on any port (for development)
-      try {
-        const url = new URL(origin);
-        if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-          callback(null, true);
-          return;
-        }
-      } catch (e) {
-        // Invalid URL, continue to other checks
-      }
-
-      // Allow any IP address on ports 3000 and 3001 (for Docker direct access)
-      // Pattern: http://<any-ip>:3000 or http://<any-ip>:3001
-      try {
-        const url = new URL(origin);
-        const port = url.port
-          ? parseInt(url.port)
-          : url.protocol === "https:"
-          ? 443
-          : 80;
-
-        // Check if hostname is an IP address (IPv4 pattern)
-        const hostname = url.hostname;
-        const ipPattern = /^\d+\.\d+\.\d+\.\d+$/;
-        const isIpAddress = ipPattern.test(hostname);
-
-        if (isIpAddress && (port === 3000 || port === 3001)) {
-          trace(`[CORS] Allowing IP-based access: ${origin}`);
-          callback(null, true);
-          return;
-        }
-      } catch (e) {
-        // Invalid URL, continue to rejection
       }
 
       // Reject origin by passing false (not an Error)

--- a/backend/src/utils/config-secrets.test.ts
+++ b/backend/src/utils/config-secrets.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SECRET_MASK,
+  maskSensitiveFields,
+  restoreSensitiveFields,
+} from "./config-secrets.js";
+
+const sampleConfig = () => ({
+  environment: {
+    auth: {
+      google: {
+        enabled: true,
+        clientId: "public-client-id",
+        clientSecret: "google-secret-value",
+      },
+      sessionSecret: "session-secret-value",
+      authorizedEmails: ["admin@example.com"],
+    },
+  },
+  email: {
+    enabled: true,
+    smtp: {
+      host: "smtp.example.com",
+      port: 587,
+      auth: {
+        user: "smtp-user",
+        pass: "smtp-password",
+      },
+    },
+  },
+  openai: {
+    apiKey: "sk-test-openai-key",
+  },
+  pushNotifications: {
+    enabled: true,
+    vapidPublicKey: "vapid-public",
+    vapidPrivateKey: "vapid-private-secret",
+  },
+  analytics: {
+    openobserve: {
+      enabled: true,
+      endpoint: "https://oo.example.com",
+      username: "oo-user",
+      password: "oo-password",
+    },
+  },
+  branding: {
+    siteName: "Galleria",
+  },
+});
+
+test("maskSensitiveFields redacts known secrets and leaves non-secrets", () => {
+  const masked = maskSensitiveFields(sampleConfig());
+
+  assert.equal(masked.environment.auth.google.clientSecret, SECRET_MASK);
+  assert.equal(masked.environment.auth.sessionSecret, SECRET_MASK);
+  assert.equal(masked.email.smtp.auth.pass, SECRET_MASK);
+  assert.equal(masked.openai.apiKey, SECRET_MASK);
+  assert.equal(masked.pushNotifications.vapidPrivateKey, SECRET_MASK);
+  assert.equal(masked.analytics.openobserve.password, SECRET_MASK);
+
+  // Non-secrets preserved
+  assert.equal(masked.environment.auth.google.clientId, "public-client-id");
+  assert.equal(masked.email.smtp.auth.user, "smtp-user");
+  assert.equal(masked.pushNotifications.vapidPublicKey, "vapid-public");
+  assert.equal(masked.analytics.openobserve.username, "oo-user");
+  assert.equal(masked.branding.siteName, "Galleria");
+});
+
+test("maskSensitiveFields does not mutate the original object", () => {
+  const original = sampleConfig();
+  maskSensitiveFields(original);
+  assert.equal(original.openai.apiKey, "sk-test-openai-key");
+  assert.equal(original.environment.auth.sessionSecret, "session-secret-value");
+});
+
+test("maskSensitiveFields leaves empty secrets empty", () => {
+  const masked = maskSensitiveFields({
+    openai: { apiKey: "" },
+    environment: { auth: { sessionSecret: "", google: { clientSecret: "" } } },
+  });
+  assert.equal(masked.openai.apiKey, "");
+  assert.equal(masked.environment.auth.sessionSecret, "");
+  assert.equal(masked.environment.auth.google.clientSecret, "");
+});
+
+test("restoreSensitiveFields restores mask tokens from current config", () => {
+  const current = sampleConfig();
+  const incoming = maskSensitiveFields(current);
+  // Simulate admin toggling a non-secret
+  incoming.branding.siteName = "Updated";
+
+  restoreSensitiveFields(incoming, current);
+
+  assert.equal(incoming.environment.auth.sessionSecret, "session-secret-value");
+  assert.equal(incoming.environment.auth.google.clientSecret, "google-secret-value");
+  assert.equal(incoming.email.smtp.auth.pass, "smtp-password");
+  assert.equal(incoming.openai.apiKey, "sk-test-openai-key");
+  assert.equal(incoming.pushNotifications.vapidPrivateKey, "vapid-private-secret");
+  assert.equal(incoming.analytics.openobserve.password, "oo-password");
+  assert.equal(incoming.branding.siteName, "Updated");
+});
+
+test("restoreSensitiveFields allows intentional clear via empty string", () => {
+  const current = sampleConfig();
+  const incoming = maskSensitiveFields(current);
+  incoming.openai.apiKey = "";
+
+  restoreSensitiveFields(incoming, current);
+
+  assert.equal(incoming.openai.apiKey, "");
+  assert.equal(incoming.environment.auth.sessionSecret, "session-secret-value");
+});
+
+test("restoreSensitiveFields accepts a new secret value", () => {
+  const current = sampleConfig();
+  const incoming = maskSensitiveFields(current);
+  incoming.openai.apiKey = "sk-new-key";
+
+  restoreSensitiveFields(incoming, current);
+
+  assert.equal(incoming.openai.apiKey, "sk-new-key");
+});

--- a/backend/src/utils/config-secrets.ts
+++ b/backend/src/utils/config-secrets.ts
@@ -1,0 +1,88 @@
+/**
+ * Mask / restore sensitive config fields for the config API.
+ * GET responses never re-emit raw secrets; PUT restores mask tokens from disk.
+ */
+
+/** Placeholder written for non-empty secrets on GET. Presence checks stay truthy. */
+export const SECRET_MASK = "********";
+
+/** Leaf keys treated as secrets (walked recursively). */
+const SENSITIVE_KEYS = new Set([
+  "clientSecret",
+  "sessionSecret",
+  "password",
+  "apiKey",
+  "vapidPrivateKey",
+  "pass",
+]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function maskObject(obj: Record<string, unknown>): void {
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (SENSITIVE_KEYS.has(key) && typeof val === "string" && val.length > 0) {
+      obj[key] = SECRET_MASK;
+    } else if (isPlainObject(val)) {
+      maskObject(val);
+    } else if (Array.isArray(val)) {
+      for (const item of val) {
+        if (isPlainObject(item)) {
+          maskObject(item);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Deep-clone config and replace non-empty sensitive string fields with SECRET_MASK.
+ */
+export function maskSensitiveFields<T>(config: T): T {
+  if (config === null || config === undefined) {
+    return config;
+  }
+  const clone = structuredClone(config) as T;
+  if (isPlainObject(clone)) {
+    maskObject(clone);
+  }
+  return clone;
+}
+
+/**
+ * When a sensitive field is still SECRET_MASK, keep the on-disk value so a
+ * round-trip save does not wipe secrets the admin did not re-enter.
+ * Empty strings are left alone (intentional clear).
+ */
+export function restoreSensitiveFields(
+  incoming: unknown,
+  current: unknown
+): void {
+  if (!isPlainObject(incoming) || !isPlainObject(current)) {
+    return;
+  }
+
+  for (const key of Object.keys(incoming)) {
+    const inVal = incoming[key];
+    const curVal = current[key];
+
+    if (SENSITIVE_KEYS.has(key) && typeof inVal === "string") {
+      if (inVal === SECRET_MASK && typeof curVal === "string") {
+        incoming[key] = curVal;
+      }
+      continue;
+    }
+
+    if (isPlainObject(inVal) && isPlainObject(curVal)) {
+      restoreSensitiveFields(inVal, curVal);
+    } else if (Array.isArray(inVal) && Array.isArray(curVal)) {
+      for (let i = 0; i < inVal.length; i++) {
+        if (isPlainObject(inVal[i]) && isPlainObject(curVal[i])) {
+          restoreSensitiveFields(inVal[i], curVal[i]);
+        }
+      }
+    }
+  }
+}

--- a/backend/src/utils/origins-equal.test.ts
+++ b/backend/src/utils/origins-equal.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { originsEqual } from './origins-equal.js';
+
+const allowed = 'https://www.example.com';
+
+test('accepts exact allowed origin', () => {
+  assert.equal(originsEqual('https://www.example.com', allowed), true);
+});
+
+test('accepts allowed origin with trailing path/slash via URL.origin', () => {
+  assert.equal(originsEqual('https://www.example.com/', allowed), true);
+  assert.equal(originsEqual('https://www.example.com/admin', allowed), true);
+  assert.equal(originsEqual(allowed, 'https://www.example.com/'), true);
+});
+
+test('rejects confusable subdomain (startsWith bypass)', () => {
+  // Previously origin.startsWith(allowed) accepted this attacker origin
+  assert.equal(originsEqual('https://www.example.com.evil.tld', allowed), false);
+  assert.equal(originsEqual('https://www.example.com.attacker.com', allowed), false);
+});
+
+test('rejects different scheme or host', () => {
+  assert.equal(originsEqual('http://www.example.com', allowed), false);
+  assert.equal(originsEqual('https://evil.example.com', allowed), false);
+  assert.equal(originsEqual('https://www.example.com:8443', allowed), false);
+});
+
+test('normalizes default HTTPS port', () => {
+  assert.equal(originsEqual('https://www.example.com:443', allowed), true);
+  assert.equal(originsEqual(allowed, 'https://www.example.com:443'), true);
+});
+
+test('rejects invalid URLs', () => {
+  assert.equal(originsEqual('not-a-url', allowed), false);
+  assert.equal(originsEqual(allowed, 'not-a-url'), false);
+  assert.equal(originsEqual('', allowed), false);
+});

--- a/backend/src/utils/origins-equal.ts
+++ b/backend/src/utils/origins-equal.ts
@@ -1,0 +1,13 @@
+/**
+ * Exact origin equality (scheme + host + port via URL.origin).
+ * Rejects confusable subdomain prefixes that string startsWith would accept
+ * (e.g. https://www.example.com.evil.tld when allowed is https://www.example.com).
+ * Regression of #537 / ticket 3439.
+ */
+export function originsEqual(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/UserCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from 'react-i18next';
 import type { User } from "./types";
-import { getGravatarUrl, copyInvitationUrl } from "./utils";
+import { getGravatarUrl, userManagementAPI } from "./utils";
 import { error, info } from '../../../../../utils/logger';
 
 interface UserCardProps {
@@ -46,10 +46,9 @@ export const UserCard: React.FC<UserCardProps> = ({
   }
 
   const handleCopyInvite = async () => {
-    if (!user.invite_token) return;
-    
     try {
-      await copyInvitationUrl(user.invite_token);
+      const { inviteUrl } = await userManagementAPI.getInviteLink(user.id);
+      await navigator.clipboard.writeText(inviteUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -454,7 +453,7 @@ export const UserCard: React.FC<UserCardProps> = ({
       {currentUser && (
         <>
           {/* Invited/Expired Users - Show Copy Invite */}
-          {(user.status === "invited" || user.status === "invite_expired") && user.invite_token && (
+          {(user.status === "invited" || user.status === "invite_expired") && (
             <div
               style={{
                 display: "flex",

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/types.ts
@@ -9,6 +9,7 @@ export interface User {
   auth_methods: string[];
   status?: string;
   picture?: string;
+  /** Present only on create-invite response, never on list payload */
   invite_token?: string | null;
 }
 

--- a/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
+++ b/frontend/src/components/AdminPortal/ConfigManager/sections/UserManagement/utils.ts
@@ -70,6 +70,17 @@ export const userManagementAPI = {
     return data.users || [];
   },
 
+  async getInviteLink(userId: number): Promise<{ inviteUrl: string }> {
+    const res = await fetch(`${API_URL}/api/auth-extended/users/${userId}/invite-link`, {
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to get invitation link');
+    }
+    return await res.json();
+  },
+
   async checkSmtpConfig() {
     const res = await fetch(`${API_URL}/api/config`, {
       credentials: 'include',


### PR DESCRIPTION
Combines 8 tickets into a single deployment:

- **#3445**: [security-audit] Password-reset request leaks MFA-enabled account existence
- **#3439**: [security-audit] CSRF origin check still uses startsWith — confusable subdomain bypass
- **#3443**: [security-audit] GET /users still requireAuth and returns invite tokens to viewers
- **#3441**: [security-audit] Path traversal in video custom-thumbnail upload (manager write-anywhere)
- **#3442**: [security-audit] Video routes still reflect Origin with credentials (CORS allowlist bypass)
- **#3440**: [security-audit] MFA disable and backup-codes skip re-auth for passwordless users
- **#3444**: [security-audit] Unauthenticated passkey/auth-options still enumerates users and credential IDs
- **#3438**: [security-audit] GET /api/config still returns full secrets to any authenticated user

Tracking ticket: #3476