### PR TITLE
[security-audit] analytics origin check still uses startsWith — confusable subdomain bypass

### DIFF
--- a/backend/src/routes/analytics.ts
+++ b/backend/src/routes/analytics.ts
@@ -9,6 +9,7 @@
 import { Router } from 'express';
 import config from '../config.ts';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
+import { originsEqual } from '../utils/origins-equal.js';
 
 const router = Router();
 
@@ -45,7 +46,8 @@ router.post('/track', async (req, res): Promise<void> => {
     const allowedOrigins = config.backend.allowedOrigins;
     
     if (origin) {
-      const isAllowedOrigin = allowedOrigins.some((allowed: string) => origin.startsWith(allowed));
+      // Exact origin match (not startsWith — confusable subdomain bypass; same as CSRF #3439)
+      const isAllowedOrigin = allowedOrigins.some((allowed: string) => originsEqual(origin, allowed));
       if (!isAllowedOrigin) {
         warn('Analytics request from unauthorized origin:', origin);
         res.status(403).json({ error: 'Unauthorized origin' });


### PR DESCRIPTION
# Summary — ticket 3472

## What changed

Analytics `/api/analytics/track` origin allow-list used `origin.startsWith(allowed)`, same confusable-subdomain bypass fixed for CSRF in #3439. Attacker origin `https://www.example.com.evil.tld` was accepted when allow-list held `https://www.example.com`.

Replaced with `originsEqual(origin, allowed)` from `backend/src/utils/origins-equal.ts`. That helper compares `URL.origin` on both sides, so full Referer URLs (path/query) still match correctly without a separate normalize step.

## Files

- `backend/src/routes/analytics.ts` — import `originsEqual`; swap the allow-list predicate

## Verification

- `npm ci --cache /tmp/npm-cache-galleria-3472` (root workspace install; default `~/.npm` cache was root-owned)
- `cd backend && npm test` — 68 pass, 0 fail (includes `origins-equal.test.ts` confusable-subdomain cases)

## Notes

- No PR URL from this runtime; worker publishes.
- Diff is one-line logic + import; no CSRF/security.ts changes.

Implements Orchestrator ticket #3472.