### PR TITLE
Do not cancel active Galleria deployments

### DIFF
--- a/.github/workflows/devel-update.yml
+++ b/.github/workflows/devel-update.yml
@@ -13,7 +13,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never interrupt an active deployment. GitHub keeps the newest pending run
+  # in this group, so rapid pushes coalesce without reporting a healthy deploy
+  # as canceled or leaving its tracking ticket stranded.
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/prod-update.yml
+++ b/.github/workflows/prod-update.yml
@@ -13,7 +13,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never interrupt an active deployment. GitHub keeps the newest pending run
+  # in this group, so rapid pushes coalesce without reporting a healthy deploy
+  # as canceled or leaving its tracking ticket stranded.
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
Keeps the active devel or production deployment running while GitHub coalesces rapid pushes into the newest pending run. This prevents healthy VM deploys from being reported as canceled and stranding their tracking tickets.