### PR TITLE
[bug-scan] Session cookie domain is invalid on multi-label public suffixes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts src/utils/session-cookie-domain.test.ts"
   },
   "keywords": [],
   "author": "",
@@ -43,6 +43,7 @@
     "passport-google-oauth20": "^2.0.0",
     "qrcode": "^1.5.4",
     "speakeasy": "^2.0.0",
+    "tldts": "^7.4.9",
     "typescript": "^5.8.3",
     "web-push": "^3.6.7"
   },

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -46,6 +46,7 @@ import {
   trace,
 } from "./utils/logger.ts";
 import { getAlbumAccess, isRequestAuthenticated } from "./utils/album-access.ts";
+import { getSessionCookieDomain } from "./utils/session-cookie-domain.ts";
 
 // Initialize logger early with config or environment variable
 initLogger(getLogLevel());
@@ -376,21 +377,6 @@ if (!sessionSecret) {
   }
 }
 
-// Helper to extract base domain from hostname (e.g., 'api.example.com' -> '.example.com')
-function getBaseDomain(hostname: string): string | undefined {
-  const parts = hostname.split(".");
-  if (parts.length >= 2) {
-    return "." + parts.slice(-2).join(".");
-  }
-  return undefined;
-}
-
-// Helper to check if hostname is an IP address or localhost
-function isLocalOrIP(hostname: string): boolean {
-  const isIpAddress = /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname);
-  return hostname === "localhost" || hostname === "127.0.0.1" || isIpAddress;
-}
-
 // Initialize SQLite session store
 const db = initializeDatabase();
 const SqliteStore = SqliteStoreFactory(session);
@@ -407,7 +393,7 @@ app.use((req: Request, res: Response, next) => {
   // Store computed values on request for session middleware to use
   (req as any).__cookieSecure = isSecure;
   (req as any).__cookieSameSite = isSecure ? "lax" : false;
-  (req as any).__cookieDomain = isLocalOrIP(host) ? undefined : getBaseDomain(host);
+  (req as any).__cookieDomain = getSessionCookieDomain(host);
 
   debug(`[Session Cookie] host=${host}, secure=${isSecure}, domain=${(req as any).__cookieDomain}`);
   next();
@@ -465,21 +451,26 @@ app.use((req: Request, res: Response, next) => {
     // Clear cookies on all possible domains to handle domain changes
     // This ensures old cookies from different domain configurations are removed
     const hostname = req.hostname;
-    const baseDomain = getBaseDomain(hostname);
+    const cookieDomain = getSessionCookieDomain(hostname);
     const clearCookieOptions = { path: "/", httpOnly: true };
 
     // Clear on exact hostname (e.g., api-docker.tedcharles.net)
     res.clearCookie("connect.sid", { ...clearCookieOptions, domain: hostname });
 
-    // Clear on base domain (e.g., .tedcharles.net)
-    if (baseDomain) {
-      res.clearCookie("connect.sid", { ...clearCookieOptions, domain: baseDomain });
+    // Clear on the registrable domain (e.g., .tedcharles.net)
+    if (cookieDomain) {
+      res.clearCookie("connect.sid", {
+        ...clearCookieOptions,
+        domain: cookieDomain,
+      });
     }
 
     // Clear without explicit domain (browser default)
     res.clearCookie("connect.sid", clearCookieOptions);
 
-    debug(`[Session] Cleared cookies on domains: ${hostname}, ${baseDomain || 'none'}, default`);
+    debug(
+      `[Session] Cleared cookies on domains: ${hostname}, ${cookieDomain || "none"}, default`
+    );
 
     req.session.regenerate((err) => {
       if (err) {

--- a/backend/src/utils/session-cookie-domain.test.ts
+++ b/backend/src/utils/session-cookie-domain.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getSessionCookieDomain } from "./session-cookie-domain.js";
+
+test("derives cookie domains using multi-label public suffixes", () => {
+  assert.equal(
+    getSessionCookieDomain("api.example.co.uk"),
+    ".example.co.uk"
+  );
+  assert.equal(
+    getSessionCookieDomain("photos.example.com.au"),
+    ".example.com.au"
+  );
+  assert.equal(
+    getSessionCookieDomain("admin.example.co.jp"),
+    ".example.co.jp"
+  );
+});
+
+test("derives cookie domains using private public suffixes", () => {
+  assert.equal(
+    getSessionCookieDomain("api.tenant.github.io"),
+    ".tenant.github.io"
+  );
+});
+
+test("preserves ordinary registrable-domain behavior", () => {
+  assert.equal(getSessionCookieDomain("api.example.com"), ".example.com");
+  assert.equal(getSessionCookieDomain("EXAMPLE.COM."), ".example.com");
+});
+
+test("uses host-only cookies when no registrable domain exists", () => {
+  assert.equal(getSessionCookieDomain("co.uk"), undefined);
+  assert.equal(getSessionCookieDomain("github.io"), undefined);
+  assert.equal(getSessionCookieDomain("localhost"), undefined);
+  assert.equal(getSessionCookieDomain("127.0.0.1"), undefined);
+  assert.equal(getSessionCookieDomain("::1"), undefined);
+  assert.equal(getSessionCookieDomain(""), undefined);
+});

--- a/backend/src/utils/session-cookie-domain.ts
+++ b/backend/src/utils/session-cookie-domain.ts
@@ -1,0 +1,18 @@
+import { getDomain } from "tldts";
+
+/**
+ * Return a cookie domain shared by subdomains of the same registrable domain.
+ * Hosts without a registrable domain use the browser's host-only default.
+ */
+export function getSessionCookieDomain(hostname: string): string | undefined {
+  const normalizedHostname = hostname.trim().toLowerCase().replace(/\.$/, "");
+  if (!normalizedHostname) {
+    return undefined;
+  }
+
+  const registrableDomain = getDomain(normalizedHostname, {
+    allowPrivateDomains: true,
+  });
+
+  return registrableDomain ? `.${registrableDomain}` : undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "passport-google-oauth20": "^2.0.0",
         "qrcode": "^1.5.4",
         "speakeasy": "^2.0.0",
+        "tldts": "^7.4.9",
         "typescript": "^5.8.3",
         "web-push": "^3.6.7"
       },
@@ -2934,28 +2935,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@simplewebauthn/server": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-9.0.3.tgz",
-      "integrity": "sha512-FMZieoBosrVLFxCnxPFD9Enhd1U7D8nidVDT4MsHc6l4fdVcjoeHjDueeXCloO1k5O/fZg1fsSXXPKbY2XTzDA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@hexagon/base64": "^1.1.27",
-        "@levischuck/tiny-cbor": "^0.2.2",
-        "@peculiar/asn1-android": "^2.3.10",
-        "@peculiar/asn1-ecc": "^2.3.8",
-        "@peculiar/asn1-rsa": "^2.3.8",
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/asn1-x509": "^2.3.8",
-        "@simplewebauthn/types": "^9.0.1",
-        "cross-fetch": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/@simplewebauthn/types": {
       "version": "9.0.1",
@@ -8690,6 +8669,24 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",


### PR DESCRIPTION
Implemented a Public Suffix List-aware session cookie-domain calculation. Requests to hosts such as `api.example.co.uk` now scope the session cookie to `.example.co.uk` instead of the rejected `.co.uk`. The same helper is used when clearing stale cookies. Hosts without a registrable domain fall back to host-only cookies.

Important files:

- `backend/src/utils/session-cookie-domain.ts` adds the `tldts`-backed calculation, including private suffix support.
- `backend/src/utils/session-cookie-domain.test.ts` covers `co.uk`, `com.au`, `co.jp`, `github.io`, ordinary domains, localhost, IPv4, IPv6, and bare public suffixes.
- `backend/src/server.ts` uses the helper for session creation and stale-cookie cleanup.
- `backend/package.json` and `package-lock.json` add `tldts` and include the regression test in the normal backend suite.

Verification:

- `npm ci` — passed.
- Focused `node --test` for `session-cookie-domain.test.ts` — passed, 4 tests.
- `npm test --workspace backend` — passed, 72 tests.
- `npm run build --workspace backend` — passed.
- `npm run build --workspace frontend` — passed.
- Root `npm run build` — unavailable because this isolated worktree has no runtime `data/config.json`; `build.js` exits before invoking either workspace build.
- `npm run lint --workspace frontend` — existing frontend baseline is red with 220 errors and 40 warnings in untouched files. No frontend source changed.

No blockers.

Implements Orchestrator ticket #3527.