### PR TITLE
[bug-scan] Video read-stream errors can terminate the backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts src/utils/stream-file-response.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/video.ts
+++ b/backend/src/routes/video.ts
@@ -11,6 +11,7 @@ import { getAlbumState, getShareLinkBySecret, isShareLinkExpired } from '../data
 import { requireAuth } from '../auth/middleware.js';
 import { isRequestAuthenticated } from '../utils/album-access.js';
 import { isOriginAllowed } from '../config.js';
+import { streamFileToResponse } from '../utils/stream-file-response.js';
 
 const router = Router();
 
@@ -492,7 +493,6 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
       const start = parseInt(parts[0], 10);
       const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
       const chunksize = (end - start) + 1;
-      const file = fs.createReadStream(rotatedVideoPath, { start, end });
 
       res.writeHead(206, {
         'Content-Range': `bytes ${start}-${end}/${fileSize}`,
@@ -502,7 +502,7 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
         ...credentialedCorsHeaderRecord(req),
       });
 
-      file.pipe(res);
+      await streamFileToResponse(rotatedVideoPath, res, { start, end });
     } else {
       // Send entire file
       res.writeHead(200, {
@@ -512,10 +512,16 @@ router.get("/:album/:filename/original.mp4", requireAuth, async (req: Request, r
         ...credentialedCorsHeaderRecord(req),
       });
 
-      fs.createReadStream(rotatedVideoPath).pipe(res);
+      await streamFileToResponse(rotatedVideoPath, res);
     }
   } catch (err) {
     error('[Video] Failed to serve rotated video:', err);
+    if (res.headersSent) {
+      if (!res.destroyed) {
+        res.destroy();
+      }
+      return;
+    }
     res.status(500).json({ error: 'Failed to serve video' });
   }
 });

--- a/backend/src/utils/stream-file-response.test.ts
+++ b/backend/src/utils/stream-file-response.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import { streamFileToResponse } from "./stream-file-response.js";
+
+for (const range of [undefined, { start: 0, end: 1 }]) {
+  const requestType = range ? "range" : "whole-file";
+
+  test(`${requestType} stream closes the response when the file is deleted after stat`, async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "galleria-video-stream-"));
+    const videoPath = path.join(root, "album", "video.mp4", "original.mp4");
+    mkdirSync(path.dirname(videoPath), { recursive: true });
+    writeFileSync(videoPath, "video");
+
+    try {
+      statSync(videoPath);
+      unlinkSync(videoPath);
+
+      const response = new PassThrough();
+      await assert.rejects(
+        () => streamFileToResponse(videoPath, response, range),
+        (err: NodeJS.ErrnoException) => {
+          assert.equal(err.code, "ENOENT");
+          return true;
+        }
+      );
+
+      assert.equal(response.destroyed, true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/backend/src/utils/stream-file-response.ts
+++ b/backend/src/utils/stream-file-response.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import type { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+export interface FileStreamRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Stream a file into an HTTP response-compatible destination.
+ *
+ * Awaiting pipeline propagates asynchronous open/read failures to the route
+ * handler and destroys the destination when either side fails.
+ */
+export async function streamFileToResponse(
+  filePath: string,
+  destination: Writable,
+  range?: FileStreamRange
+): Promise<void> {
+  await pipeline(fs.createReadStream(filePath, range), destination);
+}


### PR DESCRIPTION
Implemented ticket #3522.

`backend/src/routes/video.ts` now awaits a shared `stream.pipeline` for both range and whole-file rotated-video responses. Asynchronous open/read failures reach the route's `catch`; if headers were already written, the handler closes the response instead of attempting a second JSON response or allowing an uncaught stream error.

Added `backend/src/utils/stream-file-response.ts` for the awaited file pipeline and `backend/src/utils/stream-file-response.test.ts` for deletion races. The regression test stats a real file, deletes it before stream open, and verifies both range and whole-file pipelines reject cleanly while destroying the response sink. Registered the test in `backend/package.json`.

Verification:

- `TS_NODE_PROJECT=backend/tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm backend/src/utils/stream-file-response.test.ts` — passed, 2 tests.
- `npm run build --workspace backend` — passed.
- `npm test --workspace backend` — passed, 70 tests.
- `npm run build --workspace frontend` — passed.
- `npm run build` — could not enter the build because this isolated worktree has no runtime `data/config.json`; `build.js` exits with `ENOENT`. Its backend and frontend compile steps were run separately and passed.
- `npm run lint --workspace frontend` — remains red on the existing frontend baseline: 220 errors and 40 warnings in unrelated files. No frontend source was changed.

`git status`/`git diff` were unavailable in the sandbox because `.git` points to `/home/ted/Development/Galleria/.git/worktrees/ticket-3522`, which is outside this isolated worktree. Source review and validation completed without changing Git metadata.

Implements Orchestrator ticket #3522.