### PR TITLE
[bug-scan] Failed expiry notifications are permanently marked delivered

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --experimental-test-module-mocks --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts src/services/share-link-expiry-tracker.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/services/share-link-expiry-tracker.test.ts
+++ b/backend/src/services/share-link-expiry-tracker.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+
+interface TestShareLink {
+  id: number;
+  album: string;
+  secret_key: string;
+  created_at: string;
+  expires_at: string;
+  notified: number;
+}
+
+type FailureStage = 'lookup' | 'translation' | 'delivery';
+
+let currentLink: TestShareLink;
+let failureStage: FailureStage | null = null;
+const notifiedLinkIds: number[] = [];
+const loggedErrors: unknown[][] = [];
+
+const database = {
+  prepare(sql: string) {
+    if (sql.includes('SELECT id, album')) {
+      return {
+        get: () => currentLink,
+      };
+    }
+
+    if (sql.includes('UPDATE share_links SET notified = 1')) {
+      return {
+        run: (linkId: number) => {
+          notifiedLinkIds.push(linkId);
+        },
+      };
+    }
+
+    throw new Error(`Unexpected SQL in test: ${sql}`);
+  },
+};
+
+mock.module('../database.js', {
+  namedExports: {
+    getDatabase: () => database,
+  },
+});
+
+mock.module('../database-users.js', {
+  namedExports: {
+    getAllUsers: () => {
+      if (failureStage === 'lookup') {
+        throw new Error('user lookup failed');
+      }
+
+      return [{ id: 7, role: 'admin' }];
+    },
+  },
+});
+
+mock.module('../i18n-backend.js', {
+  namedExports: {
+    translateNotification: async () => {
+      if (failureStage === 'translation') {
+        throw new Error('translation failed');
+      }
+
+      return 'translated';
+    },
+  },
+});
+
+mock.module('../push-notifications.js', {
+  namedExports: {
+    sendNotificationToUser: async () => {
+      if (failureStage === 'delivery') {
+        throw new Error('notification delivery failed');
+      }
+    },
+  },
+});
+
+mock.module('../utils/logger.js', {
+  namedExports: {
+    error: (...args: unknown[]) => {
+      loggedErrors.push(args);
+    },
+    info: () => {},
+    warn: () => {},
+  },
+});
+
+const {
+  cancelShareLinkExpiryTimer,
+  scheduleNewShareLinkExpiry,
+} = await import('./share-link-expiry-tracker.js');
+
+function resetTestState(): void {
+  failureStage = null;
+  notifiedLinkIds.length = 0;
+  loggedErrors.length = 0;
+}
+
+async function waitFor(predicate: () => boolean, description: string): Promise<void> {
+  const timeoutAt = Date.now() + 1_000;
+
+  while (!predicate()) {
+    if (Date.now() >= timeoutAt) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+}
+
+for (const stage of ['lookup', 'translation', 'delivery'] as const) {
+  test(`already-expired timer leaves notified unset when ${stage} fails`, async () => {
+    resetTestState();
+    failureStage = stage;
+    currentLink = {
+      id: 100,
+      album: 'expired-album',
+      secret_key: 'expired-secret',
+      created_at: new Date(Date.now() - 2_000).toISOString(),
+      expires_at: new Date(Date.now() - 1_000).toISOString(),
+      notified: 0,
+    };
+
+    scheduleNewShareLinkExpiry(currentLink.id);
+
+    await waitFor(() => loggedErrors.length > 0, `${stage} failure to be handled`);
+    assert.deepEqual(notifiedLinkIds, []);
+  });
+}
+
+for (const stage of ['lookup', 'translation', 'delivery'] as const) {
+  test(`scheduled timer leaves notified unset when ${stage} fails`, async () => {
+    resetTestState();
+    failureStage = stage;
+    currentLink = {
+      id: 200,
+      album: 'scheduled-album',
+      secret_key: 'scheduled-secret',
+      created_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 20).toISOString(),
+      notified: 0,
+    };
+
+    scheduleNewShareLinkExpiry(currentLink.id);
+
+    await waitFor(() => loggedErrors.length > 0, `${stage} failure to be handled`);
+    assert.deepEqual(notifiedLinkIds, []);
+    cancelShareLinkExpiryTimer(currentLink.id);
+  });
+}
+
+test('successful expiry notification marks the link notified', async () => {
+  resetTestState();
+  currentLink = {
+    id: 300,
+    album: 'successful-album',
+    secret_key: 'successful-secret',
+    created_at: new Date(Date.now() - 2_000).toISOString(),
+    expires_at: new Date(Date.now() - 1_000).toISOString(),
+    notified: 0,
+  };
+
+  scheduleNewShareLinkExpiry(currentLink.id);
+
+  await waitFor(() => notifiedLinkIds.length > 0, 'the notified database update');
+  assert.deepEqual(notifiedLinkIds, [currentLink.id]);
+});

--- a/backend/src/services/share-link-expiry-tracker.ts
+++ b/backend/src/services/share-link-expiry-tracker.ts
@@ -30,33 +30,29 @@ const MAX_TIMEOUT_MS = 2147483647;
  * Send notification to all admins about an expired share link
  */
 async function notifyExpiredLink(link: ShareLink): Promise<void> {
-  try {
-    const admins = getAllUsers().filter(u => u.role === 'admin');
+  const admins = getAllUsers().filter(u => u.role === 'admin');
 
-    for (const admin of admins) {
-      const title = await translateNotification(
-        'notifications.backend.shareLinkExpiredTitle',
-        { albumName: link.album }
-      );
-      const body = await translateNotification(
-        'notifications.backend.shareLinkExpiredBody',
-        { albumName: link.album }
-      );
+  for (const admin of admins) {
+    const title = await translateNotification(
+      'notifications.backend.shareLinkExpiredTitle',
+      { albumName: link.album }
+    );
+    const body = await translateNotification(
+      'notifications.backend.shareLinkExpiredBody',
+      { albumName: link.album }
+    );
 
-      await sendNotificationToUser(admin.id, {
-        title,
-        body,
-        icon: '/icon-192.png',
-        badge: '/icon-192.png',
-        tag: 'share-link-expired',
-        requireInteraction: false
-      }, 'shareLinkExpired');
-    }
-
-    info(`[ShareLinkExpiryTracker] Notified admins about expired link for album: ${link.album}`);
-  } catch (err) {
-    error('[ShareLinkExpiryTracker] Failed to notify about expired link:', err);
+    await sendNotificationToUser(admin.id, {
+      title,
+      body,
+      icon: '/icon-192.png',
+      badge: '/icon-192.png',
+      tag: 'share-link-expired',
+      requireInteraction: false
+    }, 'shareLinkExpired');
   }
+
+  info(`[ShareLinkExpiryTracker] Notified admins about expired link for album: ${link.album}`);
 }
 
 /**
@@ -216,4 +212,3 @@ export function startShareLinkExpiryTracking(): void {
   info('[ShareLinkExpiryTracker] Starting share link expiry tracking with precise timers');
   loadAndScheduleExpiryTimers();
 }
-


### PR DESCRIPTION
Fixed failed expiry notifications being marked delivered. `notifyExpiredLink` now lets user lookup, translation, and notification delivery errors reject into the existing timer error handlers, so `notified = 1` only runs after successful delivery and failed links remain eligible for the startup retry query.

Important files:

- `backend/src/services/share-link-expiry-tracker.ts` — removed the catch that converted notification failures into successful resolutions.
- `backend/src/services/share-link-expiry-tracker.test.ts` — added regression coverage for lookup, translation, and delivery failures in both already-expired and scheduled timer paths, plus the successful update path.
- `backend/package.json` — registered the new timer test and enabled Node's module-mocking flag used by the isolated dependency tests.

Verification:

- `npm ci` — completed.
- Targeted tracker test — 7/7 passed.
- `npm test --workspace backend` — 75/75 passed.
- `npm run build --workspace backend` — passed.
- `npm run build --workspace frontend` — passed.
- `npm run build` — could not start because this isolated worktree has no ignored `data/config.json`; `build.js` exits with `ENOENT` before running its component builds. Both component builds passed directly.

No steering file or newer ticket comments were present at handoff.

Implements Orchestrator ticket #3526.