### PR TITLE
[bug-scan] Visitor chart shifts dates for users east of UTC

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "TS_NODE_PROJECT=tsconfig.test.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm tests/*.test.ts",
     "preview": "vite preview",
     "start": "node server.js"
   },
@@ -40,6 +41,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "rollup-plugin-visualizer": "^6.0.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.26.1",
     "vite": "^6.3.1"

--- a/frontend/src/components/AdminPortal/Metrics/Metrics.tsx
+++ b/frontend/src/components/AdminPortal/Metrics/Metrics.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { API_URL } from '../../../config';
 import { fetchWithRateLimitCheck } from '../../../utils/fetchWrapper';
 import { formatNumber } from '../../../utils/formatters';
-import { formatDateFromMicroseconds, formatDurationDetailed } from '../../../utils/metricsHelpers';
+import { formatDateFromMicroseconds, formatDurationDetailed, formatLocalDate } from '../../../utils/metricsHelpers';
 import CustomDropdown from '../ConfigManager/components/CustomDropdown';
 import VisitorMap from './VisitorMap';
 import VisitorsChart from './VisitorsChart';
@@ -88,7 +88,7 @@ export default function Metrics() {
       for (let i = timeRange - 1; i >= 0; i--) {
         const date = new Date(today);
         date.setDate(date.getDate() - i);
-        const dateStr = date.toISOString().split('T')[0];
+        const dateStr = formatLocalDate(date);
         
         // Find if we have data for this date (normalize API date to YYYY-MM-DD format)
         const existing = actualData.find((d: any) => {

--- a/frontend/src/utils/metricsHelpers.ts
+++ b/frontend/src/utils/metricsHelpers.ts
@@ -25,6 +25,17 @@ export const formatDateFromMicroseconds = (timestamp: number): string => {
 };
 
 /**
+ * Format a Date as a local calendar date without converting it to UTC.
+ */
+export const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+/**
  * Format duration in milliseconds to HH:MM:SS format (for detailed metrics)
  */
 export const formatDurationDetailed = (ms: number): string => {
@@ -40,4 +51,3 @@ export const formatDurationDetailed = (ms: number): string => {
   
   return `${hh}:${mm}:${ss}`;
 };
-

--- a/frontend/tests/metricsHelpers.test.ts
+++ b/frontend/tests/metricsHelpers.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import process from 'node:process';
+import test from 'node:test';
+import { formatLocalDate } from '../src/utils/metricsHelpers.ts';
+
+const withTimezone = (timezone: string, run: () => void): void => {
+  const previousTimezone = process.env.TZ;
+  process.env.TZ = timezone;
+
+  try {
+    run();
+  } finally {
+    if (previousTimezone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previousTimezone;
+    }
+  }
+};
+
+test('keeps the local calendar date east of UTC', () => {
+  withTimezone('Asia/Tokyo', () => {
+    const localMidnight = new Date(2026, 6, 29);
+
+    assert.equal(localMidnight.toISOString().split('T')[0], '2026-07-28');
+    assert.equal(formatLocalDate(localMidnight), '2026-07-29');
+  });
+});
+
+test('keeps the local calendar date west of UTC', () => {
+  withTimezone('America/New_York', () => {
+    const localMidnight = new Date(2026, 6, 29);
+
+    assert.equal(formatLocalDate(localMidnight), '2026-07-29');
+  });
+});

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/utils/metricsHelpers.ts", "tests/**/*.test.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,6 +123,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
         "rollup-plugin-visualizer": "^6.0.5",
+        "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.26.1",
         "vite": "^6.3.1"


### PR DESCRIPTION
Implemented the visitor-chart date fix. The filler loop now formats each generated day from local `Date` fields instead of converting local midnight to UTC, so backend local-day buckets keep the correct `YYYY-MM-DD` label east and west of UTC.

Important files:

- `frontend/src/components/AdminPortal/Metrics/Metrics.tsx` uses `formatLocalDate` for visitor date keys.
- `frontend/src/utils/metricsHelpers.ts` defines the local calendar-date formatter.
- `frontend/tests/metricsHelpers.test.ts` covers `Asia/Tokyo` and `America/New_York`, including the reported UTC+09 regression.
- `frontend/package.json`, `frontend/tsconfig.test.json`, and `package-lock.json` add the frontend Node test command and its existing monorepo `ts-node` runner dependency.

Verification:

- `npm test --workspace=frontend` — passed, 2/2 tests.
- `npx tsc -p tsconfig.test.json` from `frontend/` — passed.
- `npx eslint src/utils/metricsHelpers.ts tests/metricsHelpers.test.ts` from `frontend/` — passed.
- `npm run build --workspace=frontend` — passed.
- `npm run build --workspace=backend` — passed.
- `npm test --workspace=backend` — passed, 68/68 tests.
- `npm run validate-translations` — passed, 72/72 files.
- `npm run lint --workspace=frontend` — repository baseline remains red with 220 existing errors and 40 warnings, including existing `Metrics.tsx` `any` and hook warnings; no new helper/test lint errors.
- Root `npm run build` cannot start without ignored runtime file `data/config.json`; both workspace builds passed independently.

Git status/diff inspection was unavailable because this sandbox's `.git` file points to missing host path `/home/ted/Development/Galleria/.git/worktrees/ticket-3528`. Source verification completed directly from the edited files.

Implements Orchestrator ticket #3528.