### PR TITLE
[bug-scan] AI title failures are discarded as successful uploads

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "TS_NODE_PROJECT=tsconfig.app.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.test.ts",
     "preview": "vite preview",
     "start": "node server.js"
   },

--- a/frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamHandlers.ts
+++ b/frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamHandlers.ts
@@ -3,10 +3,11 @@
  * Connects to single SSE endpoint for all optimization updates
  */
 
-import { UploadingImage, Photo } from '../types';
+import { UploadingImage } from '../types';
 import { API_URL } from '../../../../config';
 import { trackPhotoUploaded } from '../../../../utils/analytics';
 import { error as logError, warn, info } from '../../../../utils/logger';
+import { applyCompleteOptimizationUpdate } from './optimizationStreamState';
 
 
 interface OptimizationStreamHandlersProps {
@@ -122,31 +123,16 @@ export const createOptimizationStreamHandlers = (props: OptimizationStreamHandle
               // Complete
               if (state === 'complete') {
                 info(`[Optimization Stream] ✅ Marking ${filename} as complete`);
-                
-                // Determine if this is a video based on extension
-                const isVideo = /\.(mp4|mov|avi|mkv|webm)$/i.test(filename);
-                const mediaType = isVideo ? 'video' : 'photo';
-                
-                // For videos, thumbnails are JPG files
-                const thumbnailFilename = isVideo ? filename.replace(/\.[^.]+$/, '.jpg') : filename;
-                
-                const completedPhoto: Photo = {
-                  id: `${album}/${filename}`,
-                  thumbnail: `/optimized/thumbnail/${encodeURIComponent(album)}/${encodeURIComponent(thumbnailFilename)}`,
-                  modal: `/optimized/modal/${encodeURIComponent(album)}/${encodeURIComponent(thumbnailFilename)}`,
-                  download: isVideo ? '' : `/optimized/download/${encodeURIComponent(album)}/${encodeURIComponent(filename)}`,
-                  title: title || '',
-                  album: album,
-                  media_type: mediaType
-                };
 
                 trackPhotoUploaded(album, 1, [filename]);
 
-                return {
-                  ...img,
-                  state: 'complete',
-                  photo: completedPhoto
-                };
+                return applyCompleteOptimizationUpdate(img, {
+                  state,
+                  album,
+                  filename,
+                  title,
+                  error
+                });
               }
 
               // Error
@@ -209,4 +195,3 @@ export const createOptimizationStreamHandlers = (props: OptimizationStreamHandle
     disconnectOptimizationStream
   };
 };
-

--- a/frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.test.ts
+++ b/frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { UploadingImage } from '../types.ts';
+import { applyCompleteOptimizationUpdate } from './optimizationStreamState.ts';
+
+const uploadingImage = {
+  file: {} as File,
+  filename: 'Lake.jpg',
+  state: 'generating-title'
+} satisfies UploadingImage;
+
+test('preserves an AI title error from a complete SSE payload', () => {
+  const result = applyCompleteOptimizationUpdate(uploadingImage, {
+    state: 'complete',
+    album: 'Summer',
+    filename: 'Lake.jpg',
+    error: 'AI error: title service unavailable'
+  });
+
+  assert.equal(result.state, 'complete');
+  assert.equal(result.photo?.aiError, 'AI error: title service unavailable');
+  assert.equal(result.photo?.title, '');
+});
+
+test('does not add an AI error to a successful complete SSE payload', () => {
+  const result = applyCompleteOptimizationUpdate(uploadingImage, {
+    state: 'complete',
+    album: 'Summer',
+    filename: 'Lake.jpg',
+    title: 'Still Water'
+  });
+
+  assert.equal(result.photo?.title, 'Still Water');
+  assert.equal(result.photo?.aiError, undefined);
+});

--- a/frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.ts
+++ b/frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.ts
@@ -1,0 +1,36 @@
+import type { Photo, UploadingImage } from '../types';
+
+export interface CompleteOptimizationUpdate {
+  state: 'complete';
+  album: string;
+  filename: string;
+  title?: string;
+  error?: string;
+}
+
+export const applyCompleteOptimizationUpdate = (
+  image: UploadingImage,
+  update: CompleteOptimizationUpdate
+): UploadingImage => {
+  const { album, filename, title, error } = update;
+  const isVideo = /\.(mp4|mov|avi|mkv|webm)$/i.test(filename);
+  const mediaType = isVideo ? 'video' : 'photo';
+  const thumbnailFilename = isVideo ? filename.replace(/\.[^.]+$/, '.jpg') : filename;
+
+  const completedPhoto: Photo = {
+    id: `${album}/${filename}`,
+    thumbnail: `/optimized/thumbnail/${encodeURIComponent(album)}/${encodeURIComponent(thumbnailFilename)}`,
+    modal: `/optimized/modal/${encodeURIComponent(album)}/${encodeURIComponent(thumbnailFilename)}`,
+    download: isVideo ? '' : `/optimized/download/${encodeURIComponent(album)}/${encodeURIComponent(filename)}`,
+    title: title || '',
+    album,
+    media_type: mediaType,
+    ...(error ? { aiError: error } : {})
+  };
+
+  return {
+    ...image,
+    state: 'complete',
+    photo: completedPhoto
+  };
+};


### PR DESCRIPTION
Implemented ticket #3524.

The optimization stream now preserves an AI-title failure from a `state: 'complete'` SSE update as `photo.aiError`. The upload remains complete because its optimized media is usable, while the existing `AlbumGridItem` AI-failure badge and retry control now receive the error they require.

Important files:

- `frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamHandlers.ts` routes complete updates through the tested state transition.
- `frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.ts` constructs completed photos and preserves `error` as `aiError`.
- `frontend/src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.test.ts` covers failed and successful AI-title completion payloads.
- `frontend/package.json` adds the frontend regression-test command.

Verification:

- `npm test --workspace frontend` — passed, 2 tests.
- `npx eslint src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamHandlers.ts src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.ts src/components/AdminPortal/AlbumsManager/handlers/optimizationStreamState.test.ts` from `frontend/` — passed.
- `npm run build --workspace frontend` — passed.
- `npm test --workspace backend` — passed, 68 tests.
- `npm run build --workspace backend` — passed.
- `npm run lint --workspace frontend` — failed on the repository baseline of 220 errors and 40 warnings; the targeted lint command for all changed TypeScript files passed.
- `npm run build` — could not run the root wrapper because this isolated worktree does not contain the ignored runtime file `data/config.json`; both frontend and backend builds passed independently.

The worktree's Git metadata points to an unavailable host path, so `git status` and `git diff` were not available inside the sandbox. No Git-mutating commands were run.

Implements Orchestrator ticket #3524.