### PR TITLE
[bug-scan] Photo retry buttons call backend routes that do not exist

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts src/routes/photo-retry-contract.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/ai-titles.ts
+++ b/backend/src/routes/ai-titles.ts
@@ -165,7 +165,7 @@ router.post('/stop', requireManager, (req: any, res: any) => {
  * Generate AI title for a single photo
  * Returns the title synchronously
  */
-router.post('/generate-single', requireManager, async (req: any, res: any) => {
+const generateSinglePhotoTitle = async (req: any, res: any) => {
   try {
     const { album, filename, language = 'en' } = req.body;
     
@@ -310,7 +310,10 @@ router.post('/generate-single', requireManager, async (req: any, res: any) => {
       message: err.message 
     });
   }
-});
+};
+
+router.post('/generate-single', requireManager, generateSinglePhotoTitle);
+router.post('/retry-photo', requireManager, generateSinglePhotoTitle);
 
 /**
  * POST /api/ai-titles/generate
@@ -557,4 +560,3 @@ router.post('/generate', requireManager, (req, res) => {
 });
 
 export default router;
-

--- a/backend/src/routes/image-optimization.ts
+++ b/backend/src/routes/image-optimization.ts
@@ -46,9 +46,18 @@ import { DATA_DIR, reloadConfig } from '../config.js';
 import { requireAuth, requireAdmin, requireManager } from '../auth/middleware.js';
 import { sendNotificationToUser } from '../push-notifications.js';
 import { translateNotification } from '../i18n-backend.js';
+import { broadcastOptimizationUpdate, queueOptimizationJob } from './optimization-stream.js';
 
 // Path to config.json
 const configPath = path.join(DATA_DIR, 'config.json');
+
+function isSafePathSegment(value: unknown): value is string {
+  return typeof value === 'string'
+    && value.length > 0
+    && !value.includes('..')
+    && !value.includes('/')
+    && !value.includes('\\');
+}
 
 // GET /api/image-optimization/settings - Get current optimization settings
 router.get('/settings', requireAuth, (req, res) => {
@@ -142,6 +151,66 @@ router.get('/status', requireAuth, (req, res) => {
   } else {
     res.json({ running: false });
   }
+});
+
+// POST /api/image-optimization/retry-photo - Retry optimization for one photo
+router.post('/retry-photo', requireManager, (req, res) => {
+  const { album, filename } = req.body;
+
+  if (!isSafePathSegment(album) || !isSafePathSegment(filename)) {
+    res.status(400).json({ error: 'Valid album and filename are required' });
+    return;
+  }
+
+  const sourcePath = path.join(DATA_DIR, 'photos', album, filename);
+  if (!fs.existsSync(sourcePath)) {
+    res.status(404).json({ error: 'Photo not found' });
+    return;
+  }
+
+  const projectRoot = path.resolve(__dirname, '../../../');
+  const scriptPath = path.join(projectRoot, 'scripts', 'optimize_new_image.js');
+  if (!fs.existsSync(scriptPath)) {
+    res.status(500).json({ error: 'Optimization script not found' });
+    return;
+  }
+
+  const jobId = `${album}/${filename}`;
+  queueOptimizationJob(
+    jobId,
+    album,
+    filename,
+    scriptPath,
+    projectRoot,
+    (progress) => {
+      broadcastOptimizationUpdate(jobId, {
+        album,
+        filename,
+        progress,
+        state: 'optimizing'
+      });
+    },
+    () => {
+      broadcastOptimizationUpdate(jobId, {
+        album,
+        filename,
+        progress: 100,
+        state: 'complete'
+      });
+    },
+    (optimizationError) => {
+      broadcastOptimizationUpdate(jobId, {
+        album,
+        filename,
+        progress: 0,
+        state: 'error',
+        error: optimizationError
+      });
+    }
+  );
+
+  info(`[ImageOptimization] Queued photo retry for ${jobId}`);
+  res.status(202).json({ success: true, message: 'Photo optimization queued' });
 });
 
 // POST /api/image-optimization/stop - Stop running optimization job
@@ -403,4 +472,3 @@ router.post('/optimize', requireManager, (req, res) => {
 });
 
 export default router;
-

--- a/backend/src/routes/photo-retry-contract.test.ts
+++ b/backend/src/routes/photo-retry-contract.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(testDir, '../../..');
+const frontendHandler = fs.readFileSync(
+  path.join(
+    projectRoot,
+    'frontend/src/components/AdminPortal/AlbumsManager/handlers/photoHandlers.ts'
+  ),
+  'utf8'
+);
+const server = fs.readFileSync(path.join(projectRoot, 'backend/src/server.ts'), 'utf8');
+
+const contracts = [
+  {
+    name: 'image optimization retry',
+    frontendPath: '/api/image-optimization/retry-photo',
+    routerFile: 'image-optimization.ts',
+    mount: 'app.use("/api/image-optimization", imageOptimizationRouter);'
+  },
+  {
+    name: 'AI title retry',
+    frontendPath: '/api/ai-titles/retry-photo',
+    routerFile: 'ai-titles.ts',
+    mount: 'app.use("/api/ai-titles", aiTitlesRouter);'
+  }
+];
+
+for (const contract of contracts) {
+  test(`${contract.name} frontend path is registered by the backend`, () => {
+    const router = fs.readFileSync(path.join(testDir, contract.routerFile), 'utf8');
+
+    assert.ok(
+      frontendHandler.includes(`\${API_URL}${contract.frontendPath}`),
+      `frontend must POST to ${contract.frontendPath}`
+    );
+    assert.match(
+      router,
+      /router\.post\(['"]\/retry-photo['"]/,
+      `${contract.routerFile} must register POST /retry-photo`
+    );
+    assert.ok(
+      server.includes(contract.mount),
+      `server must mount ${contract.routerFile} at ${path.dirname(contract.frontendPath)}`
+    );
+  });
+}


### PR DESCRIPTION
Implemented ticket #3525. The existing frontend retry URLs now resolve to authenticated backend routes instead of returning `404`.

`backend/src/routes/image-optimization.ts` adds `POST /api/image-optimization/retry-photo`. It validates the album and filename, verifies the source photo, queues the existing single-photo optimization script, and broadcasts progress through the existing optimization stream.

`backend/src/routes/ai-titles.ts` adds `POST /api/ai-titles/retry-photo` as an alias of the existing single-photo title generator. Both routes retain manager authentication and the router-level CSRF checks.

`backend/src/routes/photo-retry-contract.test.ts` covers both frontend/backend URL contracts, including router registration and server mounts. `backend/package.json` includes this regression test in the normal backend suite.

Verification:

- `TS_NODE_PROJECT=backend/tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm backend/src/routes/photo-retry-contract.test.ts` — passed, 2 tests.
- `npm test --prefix backend` — passed, 70 tests.
- `npm run build --prefix backend` — passed.
- `npm run build --prefix frontend` — passed.
- `npm run lint --prefix frontend` — failed on the repository baseline: 220 errors and 40 warnings across existing frontend files. No frontend source was changed.
- `npm run build` — could not start because this isolated worktree has no runtime `data/config.json`; the separately invoked frontend and backend builds both passed.

No steering file or newer ticket comment was present at handoff.

Implements Orchestrator ticket #3525.