### PR TITLE
[bug-scan] Analytics producer and metrics queries use different timestamp units

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts src/utils/analytics-timestamp.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/analytics.ts
+++ b/backend/src/routes/analytics.ts
@@ -10,6 +10,7 @@ import { Router } from 'express';
 import config from '../config.ts';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { originsEqual } from '../utils/origins-equal.js';
+import { timestampAnalyticsEvent } from '../utils/analytics-timestamp.js';
 
 const router = Router();
 
@@ -71,15 +72,16 @@ router.post('/track', async (req, res): Promise<void> => {
 
     // Add IP address to each event in the array
     const events = Array.isArray(req.body) ? req.body : [req.body];
-    const eventsWithIp = events.map((event: any) => ({
-      ...event,
+    const ingestionTime = Date.now();
+    const eventsWithIp = events.map((event: unknown) => ({
+      ...timestampAnalyticsEvent(event, ingestionTime),
       client_ip: clientIp,
     }));
 
     // Forward the event(s) to OpenObserve with authentication
     // Use newline-delimited JSON format for _multi endpoint
     const credentials = Buffer.from(`${username}:${password}`).toString('base64');
-    const ndjsonPayload = eventsWithIp.map((event: any) => JSON.stringify(event)).join('\n');
+    const ndjsonPayload = eventsWithIp.map((event) => JSON.stringify(event)).join('\n');
     
     const response = await fetch(analyticsUrl, {
       method: 'POST',
@@ -108,4 +110,3 @@ router.post('/track', async (req, res): Promise<void> => {
   });
 
 export default router;
-

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -8,6 +8,10 @@ import { Router, Request, Response } from 'express';
 import config from '../config.ts';
 import { requireAuth, requireAdmin } from '../auth/middleware.js';
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
+import {
+  analyticsTimeRange,
+  OPENOBSERVE_TIMESTAMP_SQL,
+} from '../utils/analytics-timestamp.js';
 
 const router = Router();
 
@@ -64,9 +68,7 @@ router.get('/visitors-over-time', requireAuth, async (req: Request, res: Respons
       return;
     }
     
-    // Calculate time range (OpenObserve uses microseconds)
-    const endTime = Date.now() * 1000;
-    const startTime = endTime - (days * 24 * 60 * 60 * 1000 * 1000);
+    const { startTime, endTime } = analyticsTimeRange(days);
 
     // Build the query endpoint
     const queryEndpoint = `${endpoint}${organization}/_search`;
@@ -97,7 +99,7 @@ router.get('/visitors-over-time', requireAuth, async (req: Request, res: Respons
     const sql = `
       WITH normalized AS (
         SELECT
-          date_trunc('day', to_timestamp_micros(_timestamp) ${intervalStr}) AS day_local,
+          date_trunc('day', ${OPENOBSERVE_TIMESTAMP_SQL} ${intervalStr}) AS day_local,
           replace(trim(split_part(client_ip, ',', 1)), '::ffff:', '') AS ip
         FROM "${stream}"
         WHERE client_ip IS NOT NULL
@@ -180,9 +182,7 @@ router.get('/visitor-locations', requireAuth, async (req: Request, res: Response
     // Get time range from query params (default to last 30 days)
     const days = parseInt(req.query.days as string) || 30;
     
-    // Calculate time range (OpenObserve uses microseconds)
-    const endTime = Date.now() * 1000;
-    const startTime = endTime - (days * 24 * 60 * 60 * 1000 * 1000);
+    const { startTime, endTime } = analyticsTimeRange(days);
 
     // Build the query endpoint
     const queryEndpoint = `${endpoint}${organization}/_search`;
@@ -297,9 +297,7 @@ router.get('/pageviews-by-hour', requireAuth, async (req: Request, res: Response
       return;
     }
     
-    // Calculate time range (OpenObserve uses microseconds)
-    const endTime = Date.now() * 1000;
-    const startTime = endTime - (days * 24 * 60 * 60 * 1000 * 1000);
+    const { startTime, endTime } = analyticsTimeRange(days);
 
     // Build the query endpoint
     const queryEndpoint = `${endpoint}${organization}/_search`;
@@ -326,7 +324,7 @@ router.get('/pageviews-by-hour', requireAuth, async (req: Request, res: Response
     // Query for pageviews per hour with timezone adjustment
     const sql = `
       SELECT
-        date_trunc('hour', to_timestamp_micros(_timestamp) ${intervalStr}) AS hour_local,
+        date_trunc('hour', ${OPENOBSERVE_TIMESTAMP_SQL} ${intervalStr}) AS hour_local,
         COUNT(*) AS pageviews
       FROM "${stream}"
       WHERE event_type = 'pageview'
@@ -403,9 +401,7 @@ router.get('/stats', requireAuth, async (req: Request, res: Response): Promise<v
 
     // Get time range from query params (default to last 30 days)
     const days = parseInt(req.query.days as string) || 30;
-    // Calculate time range based on the days parameter (OpenObserve uses microseconds)
-    const endTime = Date.now() * 1000; // Convert to microseconds
-    const startTime = endTime - (days * 24 * 60 * 60 * 1000 * 1000); // Convert days to microseconds
+    const { startTime, endTime } = analyticsTimeRange(days);
 
     // Build the query endpoint: {endpoint}{organization}/_search
     const queryEndpoint = `${endpoint}${organization}/_search`;
@@ -511,4 +507,3 @@ router.get('/stats', requireAuth, async (req: Request, res: Response): Promise<v
 });
 
 export default router;
-

--- a/backend/src/utils/analytics-timestamp.test.ts
+++ b/backend/src/utils/analytics-timestamp.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  analyticsTimeRange,
+  OPENOBSERVE_TIMESTAMP_SQL,
+  timestampAnalyticsEvent,
+} from './analytics-timestamp.js';
+
+test('ingested analytics timestamps match the metrics query microsecond contract', () => {
+  const occurredAt = '2026-07-29T12:00:00.000Z';
+  const occurredAtMilliseconds = Date.parse(occurredAt);
+  const queryEndMilliseconds = occurredAtMilliseconds + 5_000;
+
+  const event = timestampAnalyticsEvent(
+    { event_type: 'pageview', timestamp: occurredAt },
+    queryEndMilliseconds,
+  );
+  const { startTime, endTime } = analyticsTimeRange(30, queryEndMilliseconds);
+
+  assert.equal(event._timestamp, occurredAtMilliseconds * 1_000);
+  assert.ok(event._timestamp >= startTime);
+  assert.ok(event._timestamp <= endTime);
+  assert.equal(OPENOBSERVE_TIMESTAMP_SQL, 'to_timestamp_micros(_timestamp)');
+});
+
+test('ingestion uses a microsecond fallback for events without a valid occurrence time', () => {
+  const ingestionMilliseconds = Date.parse('2026-07-29T12:00:05.000Z');
+
+  const event = timestampAnalyticsEvent(
+    { event_type: 'pageview', timestamp: 'invalid' },
+    ingestionMilliseconds,
+  );
+
+  assert.equal(event._timestamp, ingestionMilliseconds * 1_000);
+});

--- a/backend/src/utils/analytics-timestamp.ts
+++ b/backend/src/utils/analytics-timestamp.ts
@@ -1,0 +1,51 @@
+declare const epochMicrosecondsBrand: unique symbol;
+
+export type EpochMicroseconds = number & {
+  readonly [epochMicrosecondsBrand]: 'EpochMicroseconds';
+};
+
+export const OPENOBSERVE_TIMESTAMP_SQL = 'to_timestamp_micros(_timestamp)';
+
+const MICROSECONDS_PER_MILLISECOND = 1_000;
+const MICROSECONDS_PER_DAY = 24 * 60 * 60 * 1_000 * MICROSECONDS_PER_MILLISECOND;
+
+export interface AnalyticsTimeRange {
+  startTime: EpochMicroseconds;
+  endTime: EpochMicroseconds;
+}
+
+export function millisecondsToMicroseconds(epochMilliseconds: number): EpochMicroseconds {
+  return (epochMilliseconds * MICROSECONDS_PER_MILLISECOND) as EpochMicroseconds;
+}
+
+export function timestampAnalyticsEvent(
+  event: unknown,
+  fallbackEpochMilliseconds = Date.now(),
+): Record<string, unknown> & { _timestamp: EpochMicroseconds } {
+  const normalizedEvent =
+    event !== null && typeof event === 'object' && !Array.isArray(event)
+      ? event as Record<string, unknown>
+      : {};
+  const parsedTimestamp =
+    typeof normalizedEvent.timestamp === 'string'
+      ? Date.parse(normalizedEvent.timestamp)
+      : Number.NaN;
+  const epochMilliseconds = Number.isFinite(parsedTimestamp)
+    ? parsedTimestamp
+    : fallbackEpochMilliseconds;
+
+  return {
+    ...normalizedEvent,
+    _timestamp: millisecondsToMicroseconds(epochMilliseconds),
+  };
+}
+
+export function analyticsTimeRange(
+  days: number,
+  endEpochMilliseconds = Date.now(),
+): AnalyticsTimeRange {
+  const endTime = millisecondsToMicroseconds(endEpochMilliseconds);
+  const startTime = (endTime - days * MICROSECONDS_PER_DAY) as EpochMicroseconds;
+
+  return { startTime, endTime };
+}

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -63,7 +63,6 @@ function getBaseEventData(): Partial<AnalyticsEvent> {
   const timestamp = new Date().toISOString();
   return {
     timestamp,
-    _timestamp: Date.now() * 1000000, // OpenObserve expects nanoseconds for timestamp override
     page_url: window.location.href,
     page_path: window.location.pathname,
     referrer: document.referrer || 'direct',
@@ -812,4 +811,3 @@ export function trackVideoSession(videoId: string, album: string, videoTitle: st
     engagement_rate: totalWatchTime > 0 ? Math.round((totalWatchTime / duration) * 100) : 0,
   });
 }
-


### PR DESCRIPTION
Fixed the analytics timestamp unit mismatch by moving the OpenObserve `_timestamp` override to the backend ingestion boundary. The frontend now sends its ISO occurrence time without the incorrect nanosecond value. `backend/src/utils/analytics-timestamp.ts` converts that occurrence time to a branded epoch-microsecond value, supplies a microsecond fallback for malformed events, defines the matching OpenObserve SQL conversion, and creates every metrics query range in the same unit.

Important files:

- `frontend/src/utils/analytics.ts` — removed the nanosecond `_timestamp` producer.
- `backend/src/utils/analytics-timestamp.ts` — added the shared ingestion/query microsecond contract.
- `backend/src/routes/analytics.ts` — normalizes events before sending NDJSON to OpenObserve.
- `backend/src/routes/metrics.ts` — uses the shared typed range and SQL timestamp conversion across all four metrics handlers.
- `backend/src/utils/analytics-timestamp.test.ts` and `backend/package.json` — added the ingestion-to-query contract coverage to the normal backend suite.

Verification:

- `npm ci` — passed.
- Targeted analytics timestamp contract test — 2 tests passed.
- `npm test --workspace=backend` — 70 tests passed.
- `npm run build --workspace=backend` — passed.
- `npm run build --workspace=frontend` — passed.
- `npx eslint src/utils/analytics.ts` from `frontend/` — passed.
- `npm run lint --workspace=frontend` — still fails on the repository baseline: 220 errors in unrelated existing files; the touched frontend file is clean.

Local `git status`/`git diff` were unavailable because this checkout's `.git` file points to `/home/ted/Development/Galleria/.git/worktrees/ticket-3523`, outside the isolated runtime. Source inspection and validation were completed directly in the worktree.

Implements Orchestrator ticket #3523.