### PR TITLE
[bug-scan] Folder deletion reports success after album cleanup fails

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/folder-album-deletion.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/folder-management.ts
+++ b/backend/src/routes/folder-management.ts
@@ -24,8 +24,11 @@ import {
 } from "../database.js";
 import { generateStaticJSONFiles } from "./static-json.js";
 import fs from "fs";
-import path from "path";
 import { requireAuth, requireAdmin, requireManager } from '../auth/middleware.js';
+import {
+  deleteAlbumsFromFolder,
+  FolderAlbumDeletionError,
+} from "../utils/folder-album-deletion.js";
 
 const router = Router();
 
@@ -175,57 +178,33 @@ router.delete("/:folder", requireManager, async (req: Request, res: Response): P
       const photosDir = req.app.get('photosDir');
       const optimizedDir = req.app.get('optimizedDir');
       const videoDir = req.app.get('videoDir');
-      
-      for (const album of albumsInFolder) {
-        try {
-          const albumPath = path.join(photosDir, album.name);
-          
-          // Delete from photos directory (if it exists)
-          if (fs.existsSync(albumPath)) {
-            fs.rmSync(albumPath, { recursive: true, force: true });
-          }
-          
-          // Delete from optimized directory (if exists)
-          ['thumbnail', 'modal', 'download'].forEach(dir => {
-            const optimizedPath = path.join(optimizedDir, dir, album.name);
-            if (fs.existsSync(optimizedPath)) {
-              fs.rmSync(optimizedPath, { recursive: true, force: true });
-            }
-          });
 
-          // Delete from video directory (HLS trees / original.mp4) if configured
-          if (videoDir) {
-            const videoPath = path.join(videoDir, album.name);
-            if (fs.existsSync(videoPath)) {
-              fs.rmSync(videoPath, { recursive: true, force: true });
-              info(`[FolderManagement] Deleted video directory: ${album.name}`);
-            }
-          }
-          
-          // Cancel share link expiry timers before deleting
-          try {
+      await deleteAlbumsFromFolder(
+        albumsInFolder,
+        { photosDir, optimizedDir, videoDir },
+        {
+          pathExists: targetPath => fs.existsSync(targetPath),
+          removeDirectory: targetPath => {
+            fs.rmSync(targetPath, { recursive: true, force: true });
+          },
+          cancelShareLinkTimers: async albumName => {
             const { getShareLinksForAlbum } = await import('../database.js');
             const { cancelShareLinkExpiryTimer } = await import('../services/share-link-expiry-tracker.js');
-            const existingLinks = getShareLinksForAlbum(album.name);
+            const existingLinks = getShareLinksForAlbum(albumName);
             for (const link of existingLinks) {
               cancelShareLinkExpiryTimer(link.id);
             }
-          } catch (err) {
-            error(`[FolderManagement] Failed to cancel share link timers for ${album.name}:`, err);
-          }
-          
-          // Delete all metadata for this album from database
-          deleteAlbumMetadata(album.name);
-          
-          // Delete album state from database (cascade delete will also remove share_links)
-          deleteAlbumState(album.name);
-          
-          info(`[FolderManagement] Deleted album: ${album.name}`);
-        } catch (err) {
-          error(`[FolderManagement] Failed to delete album ${album.name}:`, err);
-          // Continue deleting other albums even if one fails
+          },
+          deleteAlbumMetadata,
+          deleteAlbumState,
+          onVideoDirectoryDeleted: albumName => {
+            info(`[FolderManagement] Deleted video directory: ${albumName}`);
+          },
+          onAlbumDeleted: albumName => {
+            info(`[FolderManagement] Deleted album: ${albumName}`);
+          },
         }
-      }
+      );
     }
 
     // Delete folder state from database
@@ -277,6 +256,15 @@ router.delete("/:folder", requireManager, async (req: Request, res: Response): P
 
     res.json({ success: true });
   } catch (err) {
+    if (err instanceof FolderAlbumDeletionError) {
+      error(`[FolderManagement] Failed to delete album ${err.failedAlbums[0]}:`, err.cause);
+      res.status(500).json({
+        error: 'Failed to delete all albums; folder was not deleted',
+        failedAlbums: err.failedAlbums
+      });
+      return;
+    }
+
     error('[FolderManagement] Failed to delete folder:', err);
     res.status(500).json({ error: 'Failed to delete folder' });
   }
@@ -468,4 +456,3 @@ router.put('/sort-order', requireManager, async (req: Request, res: Response): P
 });
 
 export default router;
-

--- a/backend/src/utils/folder-album-deletion.test.ts
+++ b/backend/src/utils/folder-album-deletion.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import {
+  deleteAlbumsFromFolder,
+  FolderAlbumDeletionError,
+  type FolderAlbumDeletionDependencies,
+} from "./folder-album-deletion.js";
+
+const directories = {
+  photosDir: "/photos",
+  optimizedDir: "/optimized",
+  videoDir: "/video",
+};
+
+function createDependencies(
+  overrides: Partial<FolderAlbumDeletionDependencies> = {}
+): FolderAlbumDeletionDependencies {
+  return {
+    pathExists: () => true,
+    removeDirectory: () => undefined,
+    cancelShareLinkTimers: async () => undefined,
+    deleteAlbumMetadata: () => undefined,
+    deleteAlbumState: () => true,
+    ...overrides,
+  };
+}
+
+test("deleteAlbumsFromFolder deletes every album before resolving", async () => {
+  const events: string[] = [];
+  const dependencies = createDependencies({
+    removeDirectory: targetPath => {
+      events.push(`remove:${targetPath}`);
+    },
+    cancelShareLinkTimers: async albumName => {
+      events.push(`cancel:${albumName}`);
+    },
+    deleteAlbumMetadata: albumName => {
+      events.push(`metadata:${albumName}`);
+    },
+    deleteAlbumState: albumName => {
+      events.push(`state:${albumName}`);
+      return true;
+    },
+    onVideoDirectoryDeleted: albumName => {
+      events.push(`video:${albumName}`);
+    },
+    onAlbumDeleted: albumName => {
+      events.push(`deleted:${albumName}`);
+    },
+  });
+
+  await deleteAlbumsFromFolder(
+    [{ name: "First" }, { name: "Second" }],
+    directories,
+    dependencies
+  );
+
+  assert.deepEqual(events, [
+    `remove:${path.join("/photos", "First")}`,
+    `remove:${path.join("/optimized", "thumbnail", "First")}`,
+    `remove:${path.join("/optimized", "modal", "First")}`,
+    `remove:${path.join("/optimized", "download", "First")}`,
+    `remove:${path.join("/video", "First")}`,
+    "video:First",
+    "cancel:First",
+    "metadata:First",
+    "state:First",
+    "deleted:First",
+    `remove:${path.join("/photos", "Second")}`,
+    `remove:${path.join("/optimized", "thumbnail", "Second")}`,
+    `remove:${path.join("/optimized", "modal", "Second")}`,
+    `remove:${path.join("/optimized", "download", "Second")}`,
+    `remove:${path.join("/video", "Second")}`,
+    "video:Second",
+    "cancel:Second",
+    "metadata:Second",
+    "state:Second",
+    "deleted:Second",
+  ]);
+});
+
+test("deleteAlbumsFromFolder aborts and reports a filesystem failure", async () => {
+  const attemptedPaths: string[] = [];
+  const deletedStates: string[] = [];
+  const failure = new Error("permission denied");
+  const failingPath = path.join("/optimized", "modal", "Broken");
+  const dependencies = createDependencies({
+    removeDirectory: targetPath => {
+      attemptedPaths.push(targetPath);
+      if (targetPath === failingPath) {
+        throw failure;
+      }
+    },
+    deleteAlbumState: albumName => {
+      deletedStates.push(albumName);
+      return true;
+    },
+  });
+
+  await assert.rejects(
+    deleteAlbumsFromFolder(
+      [{ name: "Broken" }, { name: "Untouched" }],
+      directories,
+      dependencies
+    ),
+    err => {
+      assert.ok(err instanceof FolderAlbumDeletionError);
+      assert.deepEqual(err.failedAlbums, ["Broken"]);
+      assert.equal(err.cause, failure);
+      return true;
+    }
+  );
+
+  assert.equal(attemptedPaths.includes(failingPath), true);
+  assert.equal(
+    attemptedPaths.some(targetPath => targetPath.includes("Untouched")),
+    false
+  );
+  assert.deepEqual(deletedStates, []);
+});
+
+test("deleteAlbumsFromFolder treats a missing album-state delete as failure", async () => {
+  const attemptedStates: string[] = [];
+  const dependencies = createDependencies({
+    deleteAlbumState: albumName => {
+      attemptedStates.push(albumName);
+      return false;
+    },
+  });
+
+  await assert.rejects(
+    deleteAlbumsFromFolder(
+      [{ name: "Stale" }, { name: "Untouched" }],
+      directories,
+      dependencies
+    ),
+    err => {
+      assert.ok(err instanceof FolderAlbumDeletionError);
+      assert.deepEqual(err.failedAlbums, ["Stale"]);
+      assert.match(String(err.cause), /Album state was not deleted/);
+      return true;
+    }
+  );
+
+  assert.deepEqual(attemptedStates, ["Stale"]);
+});
+
+test("deleteAlbumsFromFolder aborts and reports a database exception", async () => {
+  const attemptedMetadata: string[] = [];
+  const failure = new Error("database is locked");
+  const dependencies = createDependencies({
+    deleteAlbumMetadata: albumName => {
+      attemptedMetadata.push(albumName);
+      throw failure;
+    },
+  });
+
+  await assert.rejects(
+    deleteAlbumsFromFolder(
+      [{ name: "Locked" }, { name: "Untouched" }],
+      directories,
+      dependencies
+    ),
+    err => {
+      assert.ok(err instanceof FolderAlbumDeletionError);
+      assert.deepEqual(err.failedAlbums, ["Locked"]);
+      assert.equal(err.cause, failure);
+      return true;
+    }
+  );
+
+  assert.deepEqual(attemptedMetadata, ["Locked"]);
+});

--- a/backend/src/utils/folder-album-deletion.ts
+++ b/backend/src/utils/folder-album-deletion.ts
@@ -1,0 +1,90 @@
+import path from "path";
+
+const OPTIMIZED_SUBDIRECTORIES = ["thumbnail", "modal", "download"] as const;
+
+export interface FolderAlbum {
+  name: string;
+}
+
+export interface FolderAlbumDirectories {
+  photosDir: string;
+  optimizedDir: string;
+  videoDir?: string | null;
+}
+
+export interface FolderAlbumDeletionDependencies {
+  pathExists(targetPath: string): boolean;
+  removeDirectory(targetPath: string): void;
+  cancelShareLinkTimers(albumName: string): Promise<void>;
+  deleteAlbumMetadata(albumName: string): void;
+  deleteAlbumState(albumName: string): boolean;
+  onVideoDirectoryDeleted?(albumName: string): void;
+  onAlbumDeleted?(albumName: string): void;
+}
+
+export class FolderAlbumDeletionError extends Error {
+  readonly failedAlbums: string[];
+  readonly cause: unknown;
+
+  constructor(albumName: string, cause: unknown) {
+    super(`Failed to delete album "${albumName}"`);
+    this.name = "FolderAlbumDeletionError";
+    this.failedAlbums = [albumName];
+    this.cause = cause;
+  }
+}
+
+/**
+ * Deletes each album completely, stopping at the first failure so the caller
+ * can preserve the containing folder and return a non-success response.
+ */
+export async function deleteAlbumsFromFolder(
+  albums: FolderAlbum[],
+  directories: FolderAlbumDirectories,
+  dependencies: FolderAlbumDeletionDependencies
+): Promise<void> {
+  const {
+    photosDir,
+    optimizedDir,
+    videoDir,
+  } = directories;
+
+  for (const album of albums) {
+    try {
+      const albumPath = path.join(photosDir, album.name);
+      if (dependencies.pathExists(albumPath)) {
+        dependencies.removeDirectory(albumPath);
+      }
+
+      for (const subdirectory of OPTIMIZED_SUBDIRECTORIES) {
+        const optimizedPath = path.join(
+          optimizedDir,
+          subdirectory,
+          album.name
+        );
+        if (dependencies.pathExists(optimizedPath)) {
+          dependencies.removeDirectory(optimizedPath);
+        }
+      }
+
+      if (videoDir) {
+        const videoPath = path.join(videoDir, album.name);
+        if (dependencies.pathExists(videoPath)) {
+          dependencies.removeDirectory(videoPath);
+          dependencies.onVideoDirectoryDeleted?.(album.name);
+        }
+      }
+
+      await dependencies.cancelShareLinkTimers(album.name);
+      dependencies.deleteAlbumMetadata(album.name);
+
+      if (!dependencies.deleteAlbumState(album.name)) {
+        throw new Error("Album state was not deleted");
+      }
+
+      dependencies.onAlbumDeleted?.(album.name);
+    } catch (cause) {
+      throw new FolderAlbumDeletionError(album.name, cause);
+    }
+  }
+}


### PR DESCRIPTION
Fixed folder deletion with `deleteAlbums=true` so an album cleanup failure cannot fall through to folder deletion or a success response.

I moved the per-album filesystem and database cleanup into `backend/src/utils/folder-album-deletion.ts`. It stops on the first failure and raises `FolderAlbumDeletionError` with the failed album name. `backend/src/routes/folder-management.ts` now returns HTTP 500 with `failedAlbums` and leaves the folder record intact. A false return from `deleteAlbumState` is also treated as a cleanup failure.

I added filesystem-failure, database-exception, missing-album-state, and successful multi-album coverage in `backend/src/utils/folder-album-deletion.test.ts`, and registered it in `backend/package.json`.

Verification:

- `TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/folder-album-deletion.test.ts` — passed, 4 tests.
- `npm test --prefix backend` — passed, 72 tests after final changes.
- `npm run build --prefix backend` — passed.
- `npm run build --prefix frontend` — passed with the repository's localhost-default warning.
- `npm run build` — could not start because the worktree does not contain runtime-only `data/config.json`; the independent frontend and backend builds passed.

The worktree's `.git` file points to a missing parent-worktree path, so read-only `git status` and `git diff` were unavailable.

Implements Orchestrator ticket #3521.