### PR TITLE
[bug-scan] Sanitized upload names overwrite existing album media

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node --no-warnings --loader ts-node/esm src/server.ts",
     "dev": "nodemon --exec 'node --no-warnings --loader ts-node/esm' src/server.ts",
     "build": "tsc",
-    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/origins-equal.test.ts src/utils/album-access.test.ts src/auth/session-invalidation.test.ts src/auth/reauth.test.ts src/auth/passkeys-auth-options.test.ts src/utils/session-user.test.ts src/utils/rename-rollback.test.ts src/utils/video-processor.spawn-error.test.ts src/utils/media-disk-cleanup.test.ts src/utils/move-media-disk.test.ts src/utils/publish-upload.test.ts src/config.origin-allowed.test.ts src/utils/config-secrets.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/routes/album-management.ts
+++ b/backend/src/routes/album-management.ts
@@ -48,6 +48,7 @@ import { broadcastOptimizationUpdate, queueOptimizationJob } from "./optimizatio
 import OpenAI from "openai";
 import { error, warn, info, debug, verbose } from '../utils/logger.js';
 import { rollbackRenamedPaths, type RenamedPath } from '../utils/rename-rollback.js';
+import { publishUploadWithoutOverwrite } from '../utils/publish-upload.js';
 
 const router = Router();
 const execFileAsync = promisify(execFile);
@@ -1047,8 +1048,8 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
     }
 
     // SECURITY: Sanitize filename to prevent path traversal attacks
-    const sanitizedFilename = sanitizePhotoName(file.originalname);
-    if (!sanitizedFilename) {
+    const preferredFilename = sanitizePhotoName(file.originalname);
+    if (!preferredFilename) {
       unlinkTempUpload(file.path);
       res.status(400).json({ error: 'Invalid filename. Use only alphanumeric characters, spaces, hyphens, underscores, and valid image/video extensions.' });
       return;
@@ -1063,28 +1064,30 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
       return;
     }
 
-    const destPath = path.join(albumPath, sanitizedFilename);
-    const isVideo = isVideoFile(sanitizedFilename);
+    const isVideo = isVideoFile(preferredFilename);
     const mediaType = isVideo ? 'video' : 'photo';
-    
-    if (isVideo) {
-      // For videos, copy file then delete temp (rename doesn't work across filesystems in Docker)
-      try {
-        await fs.promises.copyFile(file.path, destPath);
-        await fs.promises.unlink(file.path);
-      } catch (err: any) {
-        error(`[Upload] Failed to move video ${file.originalname}:`, err.message);
-        try {
-          fs.unlinkSync(file.path);
-        } catch (cleanupErr) {
-          // Ignore cleanup errors
-        }
-        res.status(500).json({ error: `Failed to save video: ${err.message}` });
-        return;
-      }
-    } else {
-      // For images, use sharp to auto-rotate based on EXIF orientation
-      try {
+    const stagingDir = path.join(
+      albumPath,
+      `.galleria-upload-${crypto.randomUUID()}`
+    );
+    const stagingPath = path.join(
+      stagingDir,
+      `staged${path.extname(preferredFilename)}`
+    );
+
+    let publishedUpload: Awaited<ReturnType<typeof publishUploadWithoutOverwrite>>;
+    try {
+      await fs.promises.mkdir(stagingDir);
+
+      if (isVideo) {
+        // Copy into the album filesystem before atomically publishing the final name.
+        await fs.promises.copyFile(
+          file.path,
+          stagingPath,
+          fs.constants.COPYFILE_EXCL
+        );
+      } else {
+        // For images, use sharp to auto-rotate based on EXIF orientation.
         const sharpTimeout = new Promise((_, reject) => 
           setTimeout(() => reject(new Error('Sharp processing timeout')), 120000) // 2 minute timeout
         );
@@ -1092,23 +1095,40 @@ router.post("/:album/upload", requireManager, (req: Request, res: Response, next
         await Promise.race([
           sharp(file.path)
             .rotate() // Auto-rotate based on EXIF
-            .toFile(destPath),
+            .toFile(stagingPath),
           sharpTimeout
         ]);
-    
-        // Clean up temp file
-        fs.unlinkSync(file.path);
-      } catch (err: any) {
-        error(`[Upload] Failed to process ${file.originalname}:`, err.message);
-        try {
-          fs.unlinkSync(file.path);
-        } catch (cleanupErr) {
-          // Ignore cleanup errors
-        }
-        res.status(500).json({ error: `Failed to save file: ${err.message}` });
-        return;
       }
+
+      publishedUpload = await publishUploadWithoutOverwrite(
+        stagingPath,
+        albumPath,
+        preferredFilename
+      );
+    } catch (err: any) {
+      const action = isVideo ? 'move video' : 'process';
+      error(`[Upload] Failed to ${action} ${file.originalname}:`, err.message);
+      unlinkTempUpload(stagingPath);
+      try {
+        fs.rmdirSync(stagingDir);
+      } catch {
+        // Ignore cleanup errors
+      }
+      unlinkTempUpload(file.path);
+      const mediaLabel = isVideo ? 'video' : 'file';
+      res.status(500).json({ error: `Failed to save ${mediaLabel}: ${err.message}` });
+      return;
     }
+
+    unlinkTempUpload(stagingPath);
+    try {
+      fs.rmdirSync(stagingDir);
+    } catch {
+      // Ignore cleanup errors
+    }
+    unlinkTempUpload(file.path);
+
+    const { filename: sanitizedFilename, destPath } = publishedUpload;
 
     // Track photo upload for large batch detection (photos only, not videos)
     if (!isVideo) {

--- a/backend/src/utils/publish-upload.test.ts
+++ b/backend/src/utils/publish-upload.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { publishUploadWithoutOverwrite } from "./publish-upload.js";
+
+test("publishUploadWithoutOverwrite preserves an existing normalized filename", async () => {
+  const albumPath = mkdtempSync(path.join(tmpdir(), "galleria-publish-upload-"));
+
+  try {
+    const stagedPath = path.join(albumPath, ".upload-staged.jpg");
+    const existingPath = path.join(albumPath, "Foo Bar.jpg");
+    writeFileSync(existingPath, "existing");
+    writeFileSync(stagedPath, "new");
+
+    const published = await publishUploadWithoutOverwrite(
+      stagedPath,
+      albumPath,
+      "Foo Bar.jpg"
+    );
+
+    assert.equal(published.filename, "Foo Bar 2.jpg");
+    assert.equal(readFileSync(existingPath, "utf8"), "existing");
+    assert.equal(readFileSync(published.destPath, "utf8"), "new");
+  } finally {
+    rmSync(albumPath, { recursive: true, force: true });
+  }
+});
+
+test("publishUploadWithoutOverwrite assigns unique names to concurrent uploads", async () => {
+  const albumPath = mkdtempSync(
+    path.join(tmpdir(), "galleria-publish-upload-concurrent-")
+  );
+
+  try {
+    const stagedPaths = Array.from({ length: 12 }, (_, index) => {
+      const stagedPath = path.join(albumPath, `.upload-${index}.jpg`);
+      writeFileSync(stagedPath, `upload-${index}`);
+      return stagedPath;
+    });
+
+    const published = await Promise.all(
+      stagedPaths.map((stagedPath) =>
+        publishUploadWithoutOverwrite(stagedPath, albumPath, "Same Photo.jpg")
+      )
+    );
+
+    const filenames = published.map(({ filename }) => filename);
+    assert.equal(new Set(filenames).size, stagedPaths.length);
+    assert.deepEqual(
+      filenames.sort(),
+      [
+        "Same Photo 10.jpg",
+        "Same Photo 11.jpg",
+        "Same Photo 12.jpg",
+        "Same Photo 2.jpg",
+        "Same Photo 3.jpg",
+        "Same Photo 4.jpg",
+        "Same Photo 5.jpg",
+        "Same Photo 6.jpg",
+        "Same Photo 7.jpg",
+        "Same Photo 8.jpg",
+        "Same Photo 9.jpg",
+        "Same Photo.jpg",
+      ].sort()
+    );
+
+    assert.deepEqual(
+      new Set(published.map(({ destPath }) => readFileSync(destPath, "utf8"))),
+      new Set(stagedPaths.map((_, index) => `upload-${index}`))
+    );
+  } finally {
+    rmSync(albumPath, { recursive: true, force: true });
+  }
+});

--- a/backend/src/utils/publish-upload.ts
+++ b/backend/src/utils/publish-upload.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+
+export interface PublishedUpload {
+  filename: string;
+  destPath: string;
+}
+
+function filenameForAttempt(
+  preferredFilename: string,
+  attempt: number
+): string {
+  if (attempt === 0) {
+    return preferredFilename;
+  }
+
+  const { name, ext } = path.parse(preferredFilename);
+  return `${name} ${attempt + 1}${ext}`;
+}
+
+/**
+ * Publish a completed staging file without replacing existing album media.
+ *
+ * The staging file must be on the same filesystem as albumPath. link() creates
+ * the destination atomically and fails with EEXIST if another upload claimed
+ * the same filename first.
+ */
+export async function publishUploadWithoutOverwrite(
+  stagedPath: string,
+  albumPath: string,
+  preferredFilename: string
+): Promise<PublishedUpload> {
+  if (
+    path.basename(preferredFilename) !== preferredFilename ||
+    !path.extname(preferredFilename)
+  ) {
+    throw new Error("Upload filename must be a basename with an extension");
+  }
+
+  for (let attempt = 0; ; attempt += 1) {
+    const filename = filenameForAttempt(preferredFilename, attempt);
+    const destPath = path.join(albumPath, filename);
+
+    try {
+      await fs.promises.link(stagedPath, destPath);
+      return { filename, destPath };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+        continue;
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Implemented collision-safe album uploads. Images and videos are completed in a hidden per-upload staging directory on the album filesystem, then atomically hard-linked to the first available sanitized filename. Existing media is never opened or replaced. Collisions retain the preferred normalized name when free and otherwise use `Name 2.ext`, `Name 3.ext`, and so on.

The route now uses the published filename and destination for the API response, optimization/video processing, metadata, and processing job ID, so concurrent colliding uploads receive distinct files and jobs.

## Important files

- `backend/src/routes/album-management.ts` — stages uploads, atomically publishes them, cleans temporary files, and propagates the resolved filename.
- `backend/src/utils/publish-upload.ts` — atomic no-clobber publish and unique-name selection.
- `backend/src/utils/publish-upload.test.ts` — existing-file preservation and 12-way concurrent collision coverage.
- `backend/package.json` — includes the new regression test in the backend suite.

## Verification

- `npm ci` — passed.
- `TS_NODE_PROJECT=tsconfig.json TS_NODE_TRANSPILE_ONLY=true node --test --loader ts-node/esm src/utils/publish-upload.test.ts` from `backend/` — passed, 2 tests.
- `npm run build --workspace=backend` — passed.
- `npm test --workspace=backend` — passed, 70 tests.
- `npm run build --workspace=frontend` — passed.
- `npm run validate-translations` — passed, 72 translation files.
- `npm run lint --workspace=frontend` — failed on the repository's existing frontend backlog: 220 errors and 40 warnings across untouched frontend files. No frontend source was changed.

The root `npm run build` was not used because `build.js` requires the untracked `data/config.json`; the frontend and backend builds were run directly instead.

Implements Orchestrator ticket #3520.