### PR TITLE
Fix failed deployment for batch #423

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10401,6 +10401,28 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-9.0.3.tgz",
+      "integrity": "sha512-FMZieoBosrVLFxCnxPFD9Enhd1U7D8nidVDT4MsHc6l4fdVcjoeHjDueeXCloO1k5O/fZg1fsSXXPKbY2XTzDA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@simplewebauthn/types": "^9.0.1",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary — ticket #3536

## Failure

Workflow [30456494079](https://github.com/theodorecharles/Galleria/actions/runs/30456494079) (batch #423 / commit `703fed87`):

- **Run update.sh on devel VM** — success (Iris/devel path already green).
- **Build and push Docker image** — failure on Dockerfile `npm ci` + hoist verification (exit 1).

## Root cause

Batch #423’s `package-lock.json` dropped `node_modules/@simplewebauthn/server` (v9.0.3, with `resolved`/`integrity`). Backend still declares `"@simplewebauthn/server": "^9.0.3"`.

- Docker `node:22-slim` uses **npm 10.9.8**, which rejects the lock with `EUSAGE` / `Missing: @simplewebauthn/server@9.0.3 from lock file`.
- Local npm 11 was more permissive and masked the break.

Only that one package path was missing vs pre-batch lock (`90cc4511`); transitive deps were already present.

## Fix

Surgically restored the pre-batch lock entry for `node_modules/@simplewebauthn/server@9.0.3` in `package-lock.json` (+22 lines). No application source changes.

## Verification

| Check | Result |
| --- | --- |
| `npm ci` in `node:22-slim` + Dockerfile hoist `ls` checks | pass (`@simplewebauthn/server` 9.0.3) |
| Full `docker build -t galleria-ticket-3536-test .` | pass |
| `npm run build --workspace=backend` (`tsc`) | pass |
| `frontend` `tsc -b` | pass |
| `npm test --workspace=backend` | 91 pass / 0 fail |
| `npm test --workspace=frontend` | pass (incl. vitest `App.test.tsx`) |

Local `vite build` hit worktree `.env` mode `000` (EACCES) — sandbox artifact, not product; Docker frontend build succeeded.

## Files

- `package-lock.json` — restore missing `@simplewebauthn/server@9.0.3` lock entry

## Links for PR

- Ticket #3536
- Failed workflow: https://github.com/theodorecharles/Galleria/actions/runs/30456494079
- Batch #423 components: #3520/#354, #3521/#353, #3522/#347, #3523/#352, #3524/#350, #3525/#351, #3526/#348, #3527/#346, #3528/#349, #3529/#355

Implements Orchestrator ticket #3536.